### PR TITLE
Add init command

### DIFF
--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import csv
 import os
 import pkg_resources
 import sys
@@ -20,14 +21,33 @@ def init(args):
     # Store COGS configuration
     # If this already exists, it *will* be overwritten
     with open(".cogs/config.tsv", "w") as f:
+        writer = csv.writer(f, delimiter='\t', lineterminator='\n')
         v = pkg_resources.require("COGS")[0].version
-        f.write("COGS\thttps://github.com/ontodev/cogs\n")
-        f.write(f"COGS Version\t{v}\n")
+        writer.writerow(["COGS", "https://github.com/ontodev/cogs"])
+        writer.writerow(["COGS Version", v])
 
     # Init sheet.tsv and field.tsv
-    # If these already exist, they will not be overwritten
-    open(".cogs/sheet.tsv", "a").close()
-    open(".cogs/field.tsv", "a").close()
+    # If these already exist, they will not be overwritten (unless they are empty)
+    create = False
+    if not os.path.exists(".cogs/sheet.tsv"):
+        create = True
+    elif os.stat(".cogs/sheet.tsv").st_size == 0:
+        create = True
+    if create:
+        with open(".cogs/sheet.tsv", "w") as f:
+            writer = csv.writer(f, delimiter='\t', lineterminator='\n')
+            writer.writerow(["Sheet", "Label", "File Path", "Description"])
+
+    create = False
+    if not os.path.exists(".cogs/field.tsv"):
+        create = True
+    elif os.stat(".cogs/field.tsv").st_size == 0:
+        create = True
+    if create:
+        with open(".cogs/field.tsv", "w") as f:
+            writer = csv.writer(f, delimiter='\t', lineterminator='\n')
+            writer.writerow(["Field", "Label", "Datatype", "Description"])
+            writer.writerows(default_fields)
     sys.exit(0)
 
 
@@ -50,6 +70,21 @@ def main():
 
     args = parser.parse_args()
     args.func(args)
+
+
+default_fields = [
+    ["sheet", "Sheet", "cogs:sql_id", "The identifier for this sheet"],
+    ["label", "Label", "cogs:label", "The label for this row"],
+    [
+        "file_path",
+        "File Path",
+        "cogs:file_path",
+        "The relative path of the TSV file for this sheet",
+    ],
+    ["description", "Description", "cogs:text", "A description of this row"],
+    ["field", "Field", "cogs:sql_id", "The identifier for this field"],
+    ["datatype", "Datatype", "cogs:curie", "The datatype for this row"],
+]
 
 
 if __name__ == "__main__":

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -28,22 +28,12 @@ def init(args):
 
     # Init sheet.tsv and field.tsv
     # If these already exist, they will not be overwritten (unless they are empty)
-    create = False
-    if not os.path.exists(".cogs/sheet.tsv"):
-        create = True
-    elif os.stat(".cogs/sheet.tsv").st_size == 0:
-        create = True
-    if create:
+    if not os.path.exists(".cogs/sheet.tsv") or os.stat(".cogs/sheet.tsv").st_size == 0:
         with open(".cogs/sheet.tsv", "w") as f:
             writer = csv.writer(f, delimiter='\t', lineterminator='\n')
             writer.writerow(["Sheet", "Label", "File Path", "Description"])
 
-    create = False
-    if not os.path.exists(".cogs/field.tsv"):
-        create = True
-    elif os.stat(".cogs/field.tsv").st_size == 0:
-        create = True
-    if create:
+    if not os.path.exists(".cogs/field.tsv") or os.stat(".cogs/field.tsv").st_size == 0:
         with open(".cogs/field.tsv", "w") as f:
             writer = csv.writer(f, delimiter='\t', lineterminator='\n')
             writer.writerow(["Field", "Label", "Datatype", "Description"])

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -1,12 +1,38 @@
 #!/usr/bin/env python
 
+import os
 import pkg_resources
 import sys
 
 from argparse import ArgumentParser
 
 
+def init(args):
+    """Init a new .cogs configuration directory in the current working directory. If one already
+    exists, reinit it by rewriting config.tsv and ensuring that sheet.tsv and field.tsv exist."""
+    cwd = os.getcwd()
+    if not os.path.exists(".cogs"):
+        print(f"Initializing COGS configuration in {cwd}/.cogs/")
+        os.mkdir(".cogs")
+    else:
+        print(f"Reinitializing existing COGS configuration in {cwd}/.cogs/")
+
+    # Store COGS configuration
+    # If this already exists, it *will* be overwritten
+    with open(".cogs/config.tsv", "w") as f:
+        v = pkg_resources.require("COGS")[0].version
+        f.write("COGS\thttps://github.com/ontodev/cogs\n")
+        f.write(f"COGS Version\t{v}\n")
+
+    # Init sheet.tsv and field.tsv
+    # If these already exist, they will not be overwritten
+    open(".cogs/sheet.tsv", "a").close()
+    open(".cogs/field.tsv", "a").close()
+    sys.exit(0)
+
+
 def version(args):
+    """Print COGS version information."""
     v = pkg_resources.require("COGS")[0].version
     print(f"COGS version {v}")
     sys.exit(0)
@@ -18,6 +44,9 @@ def main():
 
     sp = subparsers.add_parser("version")
     sp.set_defaults(func=version)
+
+    sp = subparsers.add_parser("init")
+    sp.set_defaults(func=init)
 
     args = parser.parse_args()
     args.func(args)


### PR DESCRIPTION
Resolves #8 

```
$ cogs init
Initializing COGS configuration in /Users/tauber/github/.cogs/

$ cogs init
Reinitializing existing COGS configuration in /Users/tauber/github/.cogs/
```

The first `init` creates `.cogs` and writes `.cogs/config.tsv` with:
```
COGS	https://github.com/ontodev/cogs
COGS Version	0.0.1
```

It also creates `.cogs/sheet.tsv` and `cogs/field.tsv`

The second `init` rewrites the config (same data, but if you were to run `init` between versions, the version number would change) and touches `sheet.tsv` and `field.tsv` to make sure they exist. If either of those sheets have data, it will not be overwritten.