### PR TITLE
Update init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Options:
 - `-c`/`--credentials`: **required**, path to Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format
 - `-t`/`--title`: **required**, title of the project which will be used as the title of the Google Sheet
 - `-u`/`--user`: email of the user to share the sheet with (if a `--role` is not specified, this user will be the owner of the Sheet)
-- `-r`/`--role`: role of the user specified by `--user`: `owner`, `writer`, `viewer`
-- `-U`/`--users`: path to TSV containing emails and roles for multiple users (no header - only one `owner` should be specified)
+- `-r`/`--role`: role of the user specified by `--user`: `owner`, `writer`, `reader` (default: `owner`)
+- `-U`/`--users`: path to TSV containing emails and roles for multiple users (header optional; only one `owner` should be specified)
 
 Three files are created in the `.cogs/` directory when running `init`:
 - `config.tsv`: COGS configuration, including the Sheet details 

--- a/README.md
+++ b/README.md
@@ -10,47 +10,33 @@ COGS takes a set of TSV files on your local file system and allows you to edit t
 Since COGS is designed to synchronize local and remote sets of tables,
 we try to follow the familiar `git` interface and workflow:
 
-- `cogs init` creates a `.cogs/` directory to store configuration data and copies of the remote files
-- `cogs create` creates a Google Sheet and stores the ID in `.cogs/`
+- `cogs init` creates a `.cogs/` directory to store configuration data and creates a Google Sheet for the project
 - `cogs add foo.tsv` starts tracking the `foo.tsv` table
 - `cogs push` pushes local tables to the Google Sheet
 - `cogs fetch` fetches the data from the Goolgle Sheet and stores it in `.cogs/`
 - `cogs status` summarizes the differences between tracked files and their copies in `.cogs/`
 - `cogs diff` shows detailed differences between local files and the Google Sheet
 - `cogs pull` overwrites local files with the data from the Google Sheet, if they have changed
-- `cogs delete` destroys the Google Sheet, but leaves local files alone
+- `cogs delete` destroys the Google Sheet and configuration data, but leaves local files alone
 
 There is no step corresponding to `git commit`.
 
 ### `init`
 
-```
-cogs init -c [path-to-credentials] -u [email] -r [role]
-```
-
-`init` **requires** [Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format to be used for all sheet operations (`-c`/`-credentials`). These credentials are used to create a [`gspread`](https://gspread.readthedocs.io/en/latest/) Client that can create, share, edit, and delete Google Sheets.
-
-Optionally, you may provide a user email (`-u`/`--user`) that all sheets will be shared with when running `create`. By default, this user will have write access. You can also specify a role (`-r`/`--role`) to override this:
-- `owner` (there can only be one owner of a sheet, and any time the `owner` role is specified, the ownership will be transferred to that user)
-- `writer`
-- `viewer`
-
-You can also share with multiple users by providing the path to a TSV (`-U`, `--users`). Each line should have a user email and the role for that user, separated by a tab.
-
-Six files are created in the `.cogs/` directory when running `init`:
-- `config.tsv`: COGS configuration, including the sheet details once createdd
-- `credentials.json`: Google API credentials (copied from `-c`/`--credentials`)
-- `field.tsv`: Sheet field names (contains default COGS fields)
-- `sheet.tsv`: Sheet names and details (empty)
-- `table.tsv`: Table names and details (empty)
-- `users.tsv`: User emails and roles (filled out from `-u`/`--user` and `-U`/`--users`)
-
-### `create`
+Running `init` creates a `.cogs` directory containing configuration data. This also creates a new Google Sheet and stores the Sheet ID. Optionally, this new sheet may be shared with users.
 
 ```
-cogs create -t [title] -d [description]
+cogs init -c [path-to-credentials] -t [project-title] -u [email] -r [role]
 ```
 
-Running `create` will create a new, empty, Google sheet with the given title (`-t`/`--title`). A description (`-d`/`--description`) is optional.
+Options:
+- `-c`/`--credentials`: **required**, path to Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format
+- `-t`/`--title`: **required**, title of the project which will be used as the title of the Google Sheet
+- `-u`/`--user`: email of the user to share the sheet with (if a `--role` is not specified, this user will be the owner of the Sheet)
+- `-r`/`--role`: role of the user specified by `--user`: `owner`, `writer`, `viewer`
+- `-U`/`--users`: path to TSV containing emails and roles for multiple users (no header - only one `owner` should be specified)
 
-This sheet will automatically be shared with any users specified in `init` and these details will be added to `.cogs/sheet.tsv`.
+Three files are created in the `.cogs/` directory when running `init`:
+- `config.tsv`: COGS configuration, including the Sheet details 
+- `field.tsv`: Field names used in tables (contains default COGS fields)
+- `sheet.tsv`: Table names in Sheet and details (empty) - the tables correspond to tabs in the Sheet

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # COGS Operates Google Sheets
 
-**WARNING** This project is wok in progress.
+**WARNING** This project is work in progress.
 
 COGS takes a set of TSV files on your local file system and allows you to edit them using Google Sheets.
 
@@ -21,3 +21,36 @@ we try to follow the familiar `git` interface and workflow:
 - `cogs delete` destroys the Google Sheet, but leaves local files alone
 
 There is no step corresponding to `git commit`.
+
+### `init`
+
+```
+cogs init -c [path-to-credentials] -u [email] -r [role]
+```
+
+`init` **requires** [Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format to be used for all sheet operations (`-c`/`-credentials`). These credentials are used to create a [`gspread`](https://gspread.readthedocs.io/en/latest/) Client that can create, share, edit, and delete Google Sheets.
+
+Optionally, you may provide a user email (`-u`/`--user`) that all sheets will be shared with when running `create`. By default, this user will have write access. You can also specify a role (`-r`/`--role`) to override this:
+- `owner` (there can only be one owner of a sheet, and any time the `owner` role is specified, the ownership will be transferred to that user)
+- `writer`
+- `viewer`
+
+You can also share with multiple users by providing the path to a TSV (`-U`, `--users`). Each line should have a user email and the role for that user, separated by a tab.
+
+Six files are created in the `.cogs/` directory when running `init`:
+- `config.tsv`: COGS configuration, including the sheet details once createdd
+- `credentials.json`: Google API credentials (copied from `-c`/`--credentials`)
+- `field.tsv`: Sheet field names (contains default COGS fields)
+- `sheet.tsv`: Sheet names and details (empty)
+- `table.tsv`: Table names and details (empty)
+- `users.tsv`: User emails and roles (filled out from `-u`/`--user` and `-U`/`--users`)
+
+### `create`
+
+```
+cogs create -t [title] -d [description]
+```
+
+Running `create` will create a new, empty, Google sheet with the given title (`-t`/`--title`). A description (`-d`/`--description`) is optional.
+
+This sheet will automatically be shared with any users specified in `init` and these details will be added to `.cogs/sheet.tsv`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black
 flake8
-pytest
+google
 gspread
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 black
 flake8
 pytest
+gspread

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     package_dir={'': 'src'},
     packages=find_packages(where='src'),
     python_requires='>=3.6, <4',
-    install_requires=[],
+    install_requires=["google", "gspread"],
     entry_points={
         "console_scripts": [
             "cogs = cogs.cli:main",

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -1,100 +1,11 @@
 #!/usr/bin/env python
 
-import csv
-import gspread
-import os
 import pkg_resources
 import sys
 
+import cogs.init as init
+
 from argparse import ArgumentParser
-
-
-def get_config():
-    """Get the configuration for this project as a dict."""
-    config = {}
-    with open(".cogs/config.tsv", "r") as f:
-        reader = csv.reader(f, delimiter="\t", lineterminator="\n")
-        for row in reader:
-            config[row[0]] = row[1]
-    return config
-
-
-def is_cogs_project():
-    """Validate that there is a valid COGS project in this directory."""
-    if not os.path.exists(".cogs/") or not os.path.isdir(".cogs/"):
-        print("ERROR: A COGS project has not been initialized!")
-        return False
-    for r in reqs:
-        if not os.path.exists(f".cogs/{r}") or os.stat(f".cogs/{r}").st_size == 0:
-            print(f"ERROR: COGS directory is missing {r}")
-            return False
-    return True
-
-
-def init(args):
-    """Init a new .cogs configuration directory in the current working directory. If one already
-    exists, display an error message."""
-    cwd = os.getcwd()
-    if os.path.exists(".cogs"):
-        print(f"ERROR: COGS project already exists in {cwd}/.cogs/")
-        sys.exit(1)
-
-    print(f"Initializing COGS project '{args.title}' in {cwd}/.cogs/")
-    os.mkdir(".cogs")
-
-    # Create the sheet for this project
-    gc = gspread.service_account(args.credentials)
-    sh = gc.create(args.title)
-
-    # Maybe get users and share new sheet with them
-    users = {}
-    if args.user:
-        # Default role is owner
-        role = "owner"
-        if args.role:
-            role = args.role
-        users[args.user] = role
-    if args.users:
-        with open(args.users, "r") as f:
-            reader = csv.reader(f, delimiter="\t")
-            for row in reader:
-                users[row[0]] = row[1]
-    for email, role in users.items():
-        sh.share(email, perm_type="user", role=role)
-
-    # Store COGS configuration
-    with open(".cogs/config.tsv", "w") as f:
-        writer = csv.DictWriter(
-            f, delimiter="\t", lineterminator="\n", fieldnames=["Key", "Value"]
-        )
-        v = pkg_resources.require("COGS")[0].version
-        writer.writerow({"Key": "COGS", "Value": "https://github.com/ontodev/cogs"})
-        writer.writerow({"Key": "COGS Version", "Value": v})
-        writer.writerow({"Key": "Credentials", "Value": args.credentials})
-        writer.writerow({"Key": "Title", "Value": args.title})
-        writer.writerow({"Key": "ID", "Value": sh.id})
-
-    # sheet.tsv contains table (tab) details from the Google Sheet
-    with open(".cogs/sheet.tsv", "w") as f:
-        writer = csv.DictWriter(
-            f,
-            delimiter="\t",
-            lineterminator="\n",
-            fieldnames=["ID", "Title", "Path", "Description"],
-        )
-        writer.writeheader()
-
-    # field.tsv contains the field headers used in the sheets
-    with open(".cogs/field.tsv", "w") as f:
-        writer = csv.DictWriter(
-            f,
-            delimiter="\t",
-            lineterminator="\n",
-            fieldnames=["Field", "Label", "Datatype", "Description"],
-        )
-        writer.writeheader()
-        writer.writerows(default_fields)
-    sys.exit(0)
 
 
 def version(args):
@@ -116,57 +27,15 @@ def main():
         "-c", "--credentials", required=True, help="Path to service account credentials"
     )
     sp.add_argument("-t", "--title", required=True, help="Title of the project")
-    sp.add_argument("-u", "--user", help="Email to share all sheets with")
+    sp.add_argument("-u", "--user", help="Email (user) to share all sheets with")
     sp.add_argument(
-        "-r", "--role", help="Role for user specified in email (default: writer)"
+        "-r", "--role", default="owner", help="Role for specified user (default: owner)"
     )
     sp.add_argument("-U", "--users", help="TSV containing user emails and their roles")
-    sp.set_defaults(func=init)
+    sp.set_defaults(func=init.run)
 
     args = parser.parse_args()
     args.func(args)
-
-
-default_fields = [
-    {
-        "Field": "sheet",
-        "Label": "Sheet",
-        "Datatype": "cogs:sql_id",
-        "Description": "The identifier for this sheet",
-    },
-    {
-        "Field": "label",
-        "Label": "Label",
-        "Datatype": "cogs:label",
-        "Description": "The label for this row",
-    },
-    {
-        "Field": "file_path",
-        "Label": "File Path",
-        "Datatype": "cogs:file_path",
-        "Description": "The relative path of the TSV file for this sheet",
-    },
-    {
-        "Field": "description",
-        "Label": "Description",
-        "Datatype": "cogs:text",
-        "Description": "A description of this row",
-    },
-    {
-        "Field": "field",
-        "Label": "Field",
-        "Datatype": "cogs:sql_id",
-        "Description": "The identifier for this field",
-    },
-    {
-        "Field": "datatype",
-        "Label": "Datatype",
-        "Datatype": "cogs:curie",
-        "Description": "The datatype for this row",
-    },
-]
-
-reqs = ["user.tsv", "sheet.tsv", "field.tsv", "config.tsv"]
 
 
 if __name__ == "__main__":

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -1,11 +1,58 @@
 #!/usr/bin/env python
 
 import csv
+import gspread
 import os
 import pkg_resources
 import sys
 
 from argparse import ArgumentParser
+
+reqs = ["credentials.json", "user.tsv", "sheet.tsv", "table.tsv", "config.tsv"]
+
+
+def validate():
+    """Validate that there is a valid COGS project in this directory."""
+    if not os.path.exists(".cogs/") or not os.path.isdir(".cogs/"):
+        print('ERROR: A COGS project has not been initialized!')
+        return False
+    for r in reqs:
+        if not os.path.exists(f".cogs/{r}") or os.stat(f".cogs/{r}").st_size == 0:
+            print(f'ERROR: COGS directory is missing {r} - please reinitialize and try again.')
+            return False
+    return True
+
+
+def create(args):
+    """Create a new Google Sheet and add it to existing project."""
+    if not validate():
+        sys.exit(1)
+
+    gc = gspread.service_account(filename=".cogs/credentials.json")
+
+    # Maybe get emails to share sheet with
+    emails = {}
+    with open(".cogs/user.tsv") as f:
+        next(f)
+        for line in f:
+            e = line.split("\t")[0].strip()
+            role = line.split("\t")[1].strip().lower()
+            emails[e] = role
+
+    # Create the sheet and share
+    print(f"Creating new sheet: {args.title}")
+    sh = gc.create(args.title)
+    for e, role in emails.items():
+        print(f"Sharing {args.title} with {e}")
+        sh.share(e, perm_type="user", role=role)
+
+    # Write details to sheet TSV
+    with open(".cogs/sheet.tsv", "a") as f:
+        writer = csv.writer(f, delimiter="\t", lineterminator="\n")
+        desc = ""
+        if args.description:
+            desc = args.description
+        writer.writerow([sh.id, args.title, desc])
 
 
 def init(args):
@@ -21,23 +68,54 @@ def init(args):
     # Store COGS configuration
     # If this already exists, it *will* be overwritten
     with open(".cogs/config.tsv", "w") as f:
-        writer = csv.writer(f, delimiter='\t', lineterminator='\n')
+        writer = csv.writer(f, delimiter="\t", lineterminator="\n")
         v = pkg_resources.require("COGS")[0].version
         writer.writerow(["COGS", "https://github.com/ontodev/cogs"])
         writer.writerow(["COGS Version", v])
 
-    # Init sheet.tsv and field.tsv
+    # Store credentials
+    with open(args.credentials, "r") as fr:
+        with open(".cogs/credentials.json", "w") as fw:
+            for line in fr:
+                fw.write(line)
+
+    # Init sheet.tsv, table.tsv, field.tsv, and user.tsv
     # If these already exist, they will not be overwritten (unless they are empty)
     if not os.path.exists(".cogs/sheet.tsv") or os.stat(".cogs/sheet.tsv").st_size == 0:
         with open(".cogs/sheet.tsv", "w") as f:
-            writer = csv.writer(f, delimiter='\t', lineterminator='\n')
-            writer.writerow(["Sheet", "Label", "File Path", "Description"])
+            writer = csv.writer(f, delimiter="\t", lineterminator="\n")
+            writer.writerow(["Sheet ID", "Sheet Title", "Description"])
+
+    if not os.path.exists(".cogs/table.tsv") or os.stat(".cogs/table.tsv").st_size == 0:
+        with open(".cogs/table.tsv", "w") as f:
+            writer = csv.writer(f, delimiter="\t", lineterminator="\n")
+            writer.writerow(["Table ID", "Table Title", "Sheet ID", "Path", "Description"])
 
     if not os.path.exists(".cogs/field.tsv") or os.stat(".cogs/field.tsv").st_size == 0:
         with open(".cogs/field.tsv", "w") as f:
-            writer = csv.writer(f, delimiter='\t', lineterminator='\n')
+            writer = csv.writer(f, delimiter="\t", lineterminator="\n")
             writer.writerow(["Field", "Label", "Datatype", "Description"])
             writer.writerows(default_fields)
+
+    if not os.path.exists(".cogs/user.tsv") or os.stat(".cogs/user.tsv").st_size == 0:
+        with open(".cogs/user.tsv", "w") as f:
+            writer = csv.writer(f, delimiter="\t", lineterminator="\n")
+            writer.writerow(["User", "Role"])
+
+    # Maybe add users
+    if args.user:
+        # Default role is owner (all access)
+        role = "owner"
+        if args.role:
+            role = args.role
+        with open(".cogs/user.tsv", "a") as f:
+            f.write(f"{args.user}\t{role}\n")
+
+    if args.users:
+        with open(args.users, "r") as fr:
+            emails = fr.read()
+            with open(".cogs/user.tsv", "a") as fw:
+                fw.write(emails)
     sys.exit(0)
 
 
@@ -56,7 +134,20 @@ def main():
     sp.set_defaults(func=version)
 
     sp = subparsers.add_parser("init")
+    sp.add_argument(
+        "-c", "--credentials", required=True, help="Path to service account credentials"
+    )
+    sp.add_argument("-u", "--user", help="Email to share all sheets with")
+    sp.add_argument(
+        "-r", "--role", help="Role for user specified in email (default: writer)"
+    )
+    sp.add_argument("-U", "--users", help="TSV containing user emails and their roles")
     sp.set_defaults(func=init)
+
+    sp = subparsers.add_parser("create")
+    sp.add_argument("-t", "--title", required=True, help="Title of the new spreadsheet")
+    sp.add_argument("-d", "--description", help="Description of the contents of this sheet")
+    sp.set_defaults(func=create)
 
     args = parser.parse_args()
     args.func(args)

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -26,16 +26,14 @@ def is_cogs_project():
         return False
     for r in reqs:
         if not os.path.exists(f".cogs/{r}") or os.stat(f".cogs/{r}").st_size == 0:
-            print(
-                f"ERROR: COGS directory is missing {r} - please reinitialize and try again."
-            )
+            print(f"ERROR: COGS directory is missing {r}")
             return False
     return True
 
 
 def init(args):
     """Init a new .cogs configuration directory in the current working directory. If one already
-    exists, reinit it by rewriting config.tsv and ensuring that sheet.tsv and field.tsv exist."""
+    exists, display an error message."""
     cwd = os.getcwd()
     if os.path.exists(".cogs"):
         print(f"ERROR: COGS project already exists in {cwd}/.cogs/")

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -8,17 +8,17 @@ import sys
 
 from argparse import ArgumentParser
 
-reqs = ["credentials.json", "user.tsv", "sheet.tsv", "table.tsv", "config.tsv"]
-
 
 def validate():
     """Validate that there is a valid COGS project in this directory."""
     if not os.path.exists(".cogs/") or not os.path.isdir(".cogs/"):
-        print('ERROR: A COGS project has not been initialized!')
+        print("ERROR: A COGS project has not been initialized!")
         return False
     for r in reqs:
         if not os.path.exists(f".cogs/{r}") or os.stat(f".cogs/{r}").st_size == 0:
-            print(f'ERROR: COGS directory is missing {r} - please reinitialize and try again.')
+            print(
+                f"ERROR: COGS directory is missing {r} - please reinitialize and try again."
+            )
             return False
     return True
 
@@ -89,7 +89,9 @@ def init(args):
     if not os.path.exists(".cogs/table.tsv") or os.stat(".cogs/table.tsv").st_size == 0:
         with open(".cogs/table.tsv", "w") as f:
             writer = csv.writer(f, delimiter="\t", lineterminator="\n")
-            writer.writerow(["Table ID", "Table Title", "Sheet ID", "Path", "Description"])
+            writer.writerow(
+                ["Table ID", "Table Title", "Sheet ID", "Path", "Description"]
+            )
 
     if not os.path.exists(".cogs/field.tsv") or os.stat(".cogs/field.tsv").st_size == 0:
         with open(".cogs/field.tsv", "w") as f:
@@ -146,7 +148,9 @@ def main():
 
     sp = subparsers.add_parser("create")
     sp.add_argument("-t", "--title", required=True, help="Title of the new spreadsheet")
-    sp.add_argument("-d", "--description", help="Description of the contents of this sheet")
+    sp.add_argument(
+        "-d", "--description", help="Description of the contents of this sheet"
+    )
     sp.set_defaults(func=create)
 
     args = parser.parse_args()
@@ -166,6 +170,8 @@ default_fields = [
     ["field", "Field", "cogs:sql_id", "The identifier for this field"],
     ["datatype", "Datatype", "cogs:curie", "The datatype for this row"],
 ]
+
+reqs = ["credentials.json", "user.tsv", "sheet.tsv", "table.tsv", "config.tsv"]
 
 
 if __name__ == "__main__":

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -9,7 +9,17 @@ import sys
 from argparse import ArgumentParser
 
 
-def validate():
+def get_config():
+    """Get the configuration for this project as a dict."""
+    config = {}
+    with open(".cogs/config.tsv", "r") as f:
+        reader = csv.reader(f, delimiter="\t", lineterminator="\n")
+        for row in reader:
+            config[row[0]] = row[1]
+    return config
+
+
+def is_cogs_project():
     """Validate that there is a valid COGS project in this directory."""
     if not os.path.exists(".cogs/") or not os.path.isdir(".cogs/"):
         print("ERROR: A COGS project has not been initialized!")
@@ -23,101 +33,69 @@ def validate():
     return True
 
 
-def create(args):
-    """Create a new Google Sheet and add it to existing project."""
-    if not validate():
-        sys.exit(1)
-
-    gc = gspread.service_account(filename=".cogs/credentials.json")
-
-    # Maybe get emails to share sheet with
-    emails = {}
-    with open(".cogs/user.tsv") as f:
-        next(f)
-        for line in f:
-            e = line.split("\t")[0].strip()
-            role = line.split("\t")[1].strip().lower()
-            emails[e] = role
-
-    # Create the sheet and share
-    print(f"Creating new sheet: {args.title}")
-    sh = gc.create(args.title)
-    for e, role in emails.items():
-        print(f"Sharing {args.title} with {e}")
-        sh.share(e, perm_type="user", role=role)
-
-    # Write details to sheet TSV
-    with open(".cogs/sheet.tsv", "a") as f:
-        writer = csv.writer(f, delimiter="\t", lineterminator="\n")
-        desc = ""
-        if args.description:
-            desc = args.description
-        writer.writerow([sh.id, args.title, desc])
-
-
 def init(args):
     """Init a new .cogs configuration directory in the current working directory. If one already
     exists, reinit it by rewriting config.tsv and ensuring that sheet.tsv and field.tsv exist."""
     cwd = os.getcwd()
-    if not os.path.exists(".cogs"):
-        print(f"Initializing COGS configuration in {cwd}/.cogs/")
-        os.mkdir(".cogs")
-    else:
-        print(f"Reinitializing existing COGS configuration in {cwd}/.cogs/")
+    if os.path.exists(".cogs"):
+        print(f"ERROR: COGS project already exists in {cwd}/.cogs/")
+        sys.exit(1)
 
-    # Store COGS configuration
-    # If this already exists, it *will* be overwritten
-    with open(".cogs/config.tsv", "w") as f:
-        writer = csv.writer(f, delimiter="\t", lineterminator="\n")
-        v = pkg_resources.require("COGS")[0].version
-        writer.writerow(["COGS", "https://github.com/ontodev/cogs"])
-        writer.writerow(["COGS Version", v])
+    print(f"Initializing COGS project '{args.title}' in {cwd}/.cogs/")
+    os.mkdir(".cogs")
 
-    # Store credentials
-    with open(args.credentials, "r") as fr:
-        with open(".cogs/credentials.json", "w") as fw:
-            for line in fr:
-                fw.write(line)
+    # Create the sheet for this project
+    gc = gspread.service_account(args.credentials)
+    sh = gc.create(args.title)
 
-    # Init sheet.tsv, table.tsv, field.tsv, and user.tsv
-    # If these already exist, they will not be overwritten (unless they are empty)
-    if not os.path.exists(".cogs/sheet.tsv") or os.stat(".cogs/sheet.tsv").st_size == 0:
-        with open(".cogs/sheet.tsv", "w") as f:
-            writer = csv.writer(f, delimiter="\t", lineterminator="\n")
-            writer.writerow(["Sheet ID", "Sheet Title", "Description"])
-
-    if not os.path.exists(".cogs/table.tsv") or os.stat(".cogs/table.tsv").st_size == 0:
-        with open(".cogs/table.tsv", "w") as f:
-            writer = csv.writer(f, delimiter="\t", lineterminator="\n")
-            writer.writerow(
-                ["Table ID", "Table Title", "Sheet ID", "Path", "Description"]
-            )
-
-    if not os.path.exists(".cogs/field.tsv") or os.stat(".cogs/field.tsv").st_size == 0:
-        with open(".cogs/field.tsv", "w") as f:
-            writer = csv.writer(f, delimiter="\t", lineterminator="\n")
-            writer.writerow(["Field", "Label", "Datatype", "Description"])
-            writer.writerows(default_fields)
-
-    if not os.path.exists(".cogs/user.tsv") or os.stat(".cogs/user.tsv").st_size == 0:
-        with open(".cogs/user.tsv", "w") as f:
-            writer = csv.writer(f, delimiter="\t", lineterminator="\n")
-            writer.writerow(["User", "Role"])
-
-    # Maybe add users
+    # Maybe get users and share new sheet with them
+    users = {}
     if args.user:
-        # Default role is owner (all access)
+        # Default role is owner
         role = "owner"
         if args.role:
             role = args.role
-        with open(".cogs/user.tsv", "a") as f:
-            f.write(f"{args.user}\t{role}\n")
-
+        users[args.user] = role
     if args.users:
-        with open(args.users, "r") as fr:
-            emails = fr.read()
-            with open(".cogs/user.tsv", "a") as fw:
-                fw.write(emails)
+        with open(args.users, "r") as f:
+            reader = csv.reader(f, delimiter="\t")
+            for row in reader:
+                users[row[0]] = row[1]
+    for email, role in users.items():
+        sh.share(email, perm_type="user", role=role)
+
+    # Store COGS configuration
+    with open(".cogs/config.tsv", "w") as f:
+        writer = csv.DictWriter(
+            f, delimiter="\t", lineterminator="\n", fieldnames=["Key", "Value"]
+        )
+        v = pkg_resources.require("COGS")[0].version
+        writer.writerow({"Key": "COGS", "Value": "https://github.com/ontodev/cogs"})
+        writer.writerow({"Key": "COGS Version", "Value": v})
+        writer.writerow({"Key": "Credentials", "Value": args.credentials})
+        writer.writerow({"Key": "Title", "Value": args.title})
+        writer.writerow({"Key": "ID", "Value": sh.id})
+
+    # sheet.tsv contains table (tab) details from the Google Sheet
+    with open(".cogs/sheet.tsv", "w") as f:
+        writer = csv.DictWriter(
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["ID", "Title", "Path", "Description"],
+        )
+        writer.writeheader()
+
+    # field.tsv contains the field headers used in the sheets
+    with open(".cogs/field.tsv", "w") as f:
+        writer = csv.DictWriter(
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["Field", "Label", "Datatype", "Description"],
+        )
+        writer.writeheader()
+        writer.writerows(default_fields)
     sys.exit(0)
 
 
@@ -139,6 +117,7 @@ def main():
     sp.add_argument(
         "-c", "--credentials", required=True, help="Path to service account credentials"
     )
+    sp.add_argument("-t", "--title", required=True, help="Title of the project")
     sp.add_argument("-u", "--user", help="Email to share all sheets with")
     sp.add_argument(
         "-r", "--role", help="Role for user specified in email (default: writer)"
@@ -146,32 +125,50 @@ def main():
     sp.add_argument("-U", "--users", help="TSV containing user emails and their roles")
     sp.set_defaults(func=init)
 
-    sp = subparsers.add_parser("create")
-    sp.add_argument("-t", "--title", required=True, help="Title of the new spreadsheet")
-    sp.add_argument(
-        "-d", "--description", help="Description of the contents of this sheet"
-    )
-    sp.set_defaults(func=create)
-
     args = parser.parse_args()
     args.func(args)
 
 
 default_fields = [
-    ["sheet", "Sheet", "cogs:sql_id", "The identifier for this sheet"],
-    ["label", "Label", "cogs:label", "The label for this row"],
-    [
-        "file_path",
-        "File Path",
-        "cogs:file_path",
-        "The relative path of the TSV file for this sheet",
-    ],
-    ["description", "Description", "cogs:text", "A description of this row"],
-    ["field", "Field", "cogs:sql_id", "The identifier for this field"],
-    ["datatype", "Datatype", "cogs:curie", "The datatype for this row"],
+    {
+        "Field": "sheet",
+        "Label": "Sheet",
+        "Datatype": "cogs:sql_id",
+        "Description": "The identifier for this sheet",
+    },
+    {
+        "Field": "label",
+        "Label": "Label",
+        "Datatype": "cogs:label",
+        "Description": "The label for this row",
+    },
+    {
+        "Field": "file_path",
+        "Label": "File Path",
+        "Datatype": "cogs:file_path",
+        "Description": "The relative path of the TSV file for this sheet",
+    },
+    {
+        "Field": "description",
+        "Label": "Description",
+        "Datatype": "cogs:text",
+        "Description": "A description of this row",
+    },
+    {
+        "Field": "field",
+        "Label": "Field",
+        "Datatype": "cogs:sql_id",
+        "Description": "The identifier for this field",
+    },
+    {
+        "Field": "datatype",
+        "Label": "Datatype",
+        "Datatype": "cogs:curie",
+        "Description": "The datatype for this row",
+    },
 ]
 
-reqs = ["credentials.json", "user.tsv", "sheet.tsv", "table.tsv", "config.tsv"]
+reqs = ["user.tsv", "sheet.tsv", "field.tsv", "config.tsv"]
 
 
 if __name__ == "__main__":

--- a/src/cogs/exceptions.py
+++ b/src/cogs/exceptions.py
@@ -1,0 +1,6 @@
+class CogsError(Exception):
+    """Base class for all COGS errors."""
+
+
+class InitError(CogsError):
+    """Used to indicate an error occurred during the init step."""

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -1,0 +1,60 @@
+import csv
+import google.auth.exceptions
+import gspread
+import os
+import re
+
+required_files = ["user.tsv", "sheet.tsv", "field.tsv", "config.tsv"]
+
+
+def get_client(credentials):
+    try:
+        gc = gspread.service_account(credentials)
+        gc.login()
+        return gc
+    except gspread.exceptions.APIError as e:
+        print(f"ERROR: Unable to create a Client from credentials '{credentials}'")
+        print(e.response.text)
+    except google.auth.exceptions.RefreshError as e:
+        if "invalid_grant" in str(e):
+            print(
+                "ERROR: Unable to create a Client; "
+                f"account for client_email in '{credentials}' cannot be found"
+            )
+        else:
+            print(
+                f"ERROR: Unable to create a Client; cannot refresh credentials in '{credentials}'"
+            )
+            print("CAUSE: " + str(e))
+
+
+def get_config():
+    """Get the configuration for this project as a dict."""
+    config = {}
+    with open(".cogs/config.tsv", "r") as f:
+        reader = csv.reader(f, delimiter="\t", lineterminator="\n")
+        for row in reader:
+            config[row[0]] = row[1]
+    return config
+
+
+def is_cogs_project():
+    """Validate that there is a valid COGS project in this directory."""
+    if not os.path.exists(".cogs/") or not os.path.isdir(".cogs/"):
+        print("ERROR: A COGS project has not been initialized!")
+        return False
+    for r in required_files:
+        if not os.path.exists(f".cogs/{r}") or os.stat(f".cogs/{r}").st_size == 0:
+            print(f"ERROR: COGS directory is missing {r}")
+            return False
+    return True
+
+
+def is_email(email):
+    """Check if a string matches a general email pattern (user@domain.tld)"""
+    return re.match(r"^[-.\w]+@[-\w]+\.[-\w]+$", email)
+
+
+def is_valid_role(role):
+    """Check if a string is a valid role for use with gspread."""
+    return role in ["owner", "writer", "reader"]

--- a/src/cogs/init.py
+++ b/src/cogs/init.py
@@ -117,7 +117,7 @@ def write_data(args, sheet):
         writer.writerow({"Key": "COGS Version", "Value": v})
         writer.writerow({"Key": "Credentials", "Value": args.credentials})
         writer.writerow({"Key": "Title", "Value": args.title})
-        writer.writerow({"Key": "ID", "Value": sheet.id})
+        writer.writerow({"Key": "Google Sheet ID", "Value": sheet.id})
 
     # sheet.tsv contains table (tab) details from the Google Sheet
     with open(".cogs/sheet.tsv", "w") as f:

--- a/src/cogs/init.py
+++ b/src/cogs/init.py
@@ -174,7 +174,6 @@ def init(args):
         try:
             sh.share(email, perm_type="user", role=role)
         except gspread.exceptions.APIError as e:
-            # TODO - if sharing fails, do we want to delete the Sheet and the COGS project?
             print(f"ERROR: Unable to share '{args.title}' with {email} as {role}")
             print(e.response.text)
 

--- a/src/cogs/init.py
+++ b/src/cogs/init.py
@@ -162,7 +162,7 @@ def init(args):
 
     # Create the new Sheet
     try:
-        sh = gc.create(args.title)
+        sheet = gc.create(args.title)
     except gspread.exceptions.APIError as e:
         raise InitError(
             f"ERROR: Unable to create new Sheet '{args.title}'\n"
@@ -172,13 +172,13 @@ def init(args):
     # Share with each user
     for email, role in users.items():
         try:
-            sh.share(email, perm_type="user", role=role)
+            sheet.share(email, perm_type="user", role=role)
         except gspread.exceptions.APIError as e:
             print(f"ERROR: Unable to share '{args.title}' with {email} as {role}")
             print(e.response.text)
 
     # Write data to COGS directory
-    write_data(args, sh)
+    write_data(args, sheet)
 
 
 def run(args):

--- a/src/cogs/init.py
+++ b/src/cogs/init.py
@@ -1,0 +1,193 @@
+import csv
+import gspread
+import os
+import pkg_resources
+import sys
+
+from cogs.exceptions import InitError
+from cogs.helpers import get_client, is_email, is_valid_role
+
+default_fields = [
+    {
+        "Field": "sheet",
+        "Label": "Sheet",
+        "Datatype": "cogs:sql_id",
+        "Description": "The identifier for this sheet",
+    },
+    {
+        "Field": "label",
+        "Label": "Label",
+        "Datatype": "cogs:label",
+        "Description": "The label for this row",
+    },
+    {
+        "Field": "file_path",
+        "Label": "File Path",
+        "Datatype": "cogs:file_path",
+        "Description": "The relative path of the TSV file for this sheet",
+    },
+    {
+        "Field": "description",
+        "Label": "Description",
+        "Datatype": "cogs:text",
+        "Description": "A description of this row",
+    },
+    {
+        "Field": "field",
+        "Label": "Field",
+        "Datatype": "cogs:sql_id",
+        "Description": "The identifier for this field",
+    },
+    {
+        "Field": "datatype",
+        "Label": "Datatype",
+        "Datatype": "cogs:curie",
+        "Description": "The datatype for this row",
+    },
+]
+
+
+def get_users(args):
+    """Return a dict of user emails to their roles."""
+    users = {}
+    has_owner = False
+
+    # Single user specified
+    if args.user:
+        # Validate the email
+        if not is_email(args.user):
+            raise InitError(f"ERROR: {args.user} is not a valid email")
+
+        # Validate the role
+        if not is_valid_role(args.role):
+            raise InitError(f"ERROR: '{args.role}' is not a valid role")
+        users[args.user] = args.role
+        if args.role == "owner":
+            has_owner = True
+
+    # Multiple users specified
+    if args.users:
+        if not os.path.exists(args.users):
+            raise InitError(f"ERROR: users file '{args.users}' does not exist")
+        with open(args.users, "r") as f:
+            reader = csv.reader(f, delimiter="\t")
+            i = 1
+            for row in reader:
+                email = row[0]
+                role = row[1].strip().lower()
+                if not is_email(email):
+                    if i == 1:
+                        # Skip the first line if it does not have an email in the first column
+                        # Allowing for users to have their own headers, or not
+                        continue
+                    else:
+                        # Any line past the first should always have an email in the first column
+                        raise InitError(
+                            f"ERROR: {email} is not a valid email address ({args.users}, line {i})"
+                        )
+
+                # Validate the role
+                if not is_valid_role(role):
+                    raise InitError(
+                        f"ERROR: '{role}' is not a valid role ({args.users}, line {i})"
+                    )
+
+                if role == "owner":
+                    if not has_owner:
+                        has_owner = True
+                    else:
+                        raise InitError(
+                            "ERROR: There may only be one user given the 'owner' role"
+                        )
+
+                users[email] = role
+                i += 1
+    return users
+
+
+def write_data(args, sh):
+    """Create COGS data files: config.tsv, sheet.tsv, and field.tsv."""
+    # Store COGS configuration
+    with open(".cogs/config.tsv", "w") as f:
+        writer = csv.DictWriter(
+            f, delimiter="\t", lineterminator="\n", fieldnames=["Key", "Value"]
+        )
+        v = pkg_resources.require("COGS")[0].version
+        writer.writerow({"Key": "COGS", "Value": "https://github.com/ontodev/cogs"})
+        writer.writerow({"Key": "COGS Version", "Value": v})
+        writer.writerow({"Key": "Credentials", "Value": args.credentials})
+        writer.writerow({"Key": "Title", "Value": args.title})
+        writer.writerow({"Key": "ID", "Value": sh.id})
+
+    # sheet.tsv contains table (tab) details from the Google Sheet
+    with open(".cogs/sheet.tsv", "w") as f:
+        writer = csv.DictWriter(
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["ID", "Title", "Path", "Description"],
+        )
+        writer.writeheader()
+
+    # field.tsv contains the field headers used in the sheets
+    with open(".cogs/field.tsv", "w") as f:
+        writer = csv.DictWriter(
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["Field", "Label", "Datatype", "Description"],
+        )
+        writer.writeheader()
+        writer.writerows(default_fields)
+
+
+def init(args):
+    """Init a new .cogs configuration directory in the current working directory. If one already
+        exists, display an error message."""
+    cwd = os.getcwd()
+    if os.path.exists(".cogs"):
+        print(f"ERROR: COGS project already exists in {cwd}/.cogs/")
+        sys.exit(1)
+
+    print(f"Initializing COGS project '{args.title}' in {cwd}/.cogs/")
+    os.mkdir(".cogs")
+
+    # Process supplied users
+    users = get_users(args)
+
+    # Create a Client to access API
+    gc = get_client(args.credentials)
+    if not gc:
+        raise InitError
+
+    # Create the new Sheet
+    try:
+        sh = gc.create(args.title)
+    except gspread.exceptions.APIError as e:
+        raise InitError(
+            f"ERROR: Unable to create new Sheet '{args.title}'\n"
+            f"CAUSE: {e.response.text}"
+        )
+
+    # Share with each user
+    for email, role in users.items():
+        try:
+            sh.share(email, perm_type="user", role=role)
+        except gspread.exceptions.APIError as e:
+            # TODO - if sharing fails, do we want to delete the Sheet and the COGS project?
+            print(f"ERROR: Unable to share '{args.title}' with {email} as {role}")
+            print(e.response.text)
+
+    # Write data to COGS directory
+    write_data(args, sh)
+
+
+def run(args):
+    """Wrapper for init function."""
+    try:
+        init(args)
+    except InitError as e:
+        print(str(e))
+        if os.path.exists(".cogs"):
+            os.rmdir(".cogs")
+        sys.exit(1)

--- a/src/cogs/init.py
+++ b/src/cogs/init.py
@@ -105,7 +105,7 @@ def get_users(args):
     return users
 
 
-def write_data(args, sh):
+def write_data(args, sheet):
     """Create COGS data files: config.tsv, sheet.tsv, and field.tsv."""
     # Store COGS configuration
     with open(".cogs/config.tsv", "w") as f:
@@ -117,7 +117,7 @@ def write_data(args, sh):
         writer.writerow({"Key": "COGS Version", "Value": v})
         writer.writerow({"Key": "Credentials", "Value": args.credentials})
         writer.writerow({"Key": "Title", "Value": args.title})
-        writer.writerow({"Key": "ID", "Value": sh.id})
+        writer.writerow({"Key": "ID", "Value": sheet.id})
 
     # sheet.tsv contains table (tab) details from the Google Sheet
     with open(".cogs/sheet.tsv", "w") as f:


### PR DESCRIPTION
Resolves #2 

### `init`

Running `init` creates a `.cogs` directory containing configuration data. This also creates a new Google Sheet and stores the Sheet ID. Optionally, this new sheet may be shared with users.

```
cogs init -c [path-to-credentials] -t [project-title] -u [email] -r [role]
```

Options:
- `-c`/`--credentials`: **required**, path to Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format
- `-t`/`--title`: **required**, title of the project which will be used as the title of the Google Sheet
- `-u`/`--user`: email of the user to share the sheet with (if a `--role` is not specified, this user will be the owner of the Sheet)
- `-r`/`--role`: role of the user specified by `--user`: `owner`, `writer`, `reader` (default: `owner`)
- `-U`/`--users`: path to TSV containing emails and roles for multiple users (header optional; only one `owner` should be specified)

Three files are created in the `.cogs/` directory when running `init`:
- `config.tsv`: COGS configuration, including the Sheet details 
- `field.tsv`: Field names used in tables (contains default COGS fields)
- `sheet.tsv`: Table names in Sheet and details (empty) - the tables correspond to tabs in the Sheet
