### PR TITLE
Add `delete` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ cogs init -c [path-to-credentials] -t [project-title] -u [email] -r [role]
 Options:
 - `-c`/`--credentials`: **required**, path to Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format
 - `-t`/`--title`: **required**, title of the project which will be used as the title of the Google Sheet
-- `-u`/`--user`: email of the user to share the sheet with (if a `--role` is not specified, this user will be the owner of the Sheet)
-- `-r`/`--role`: role of the user specified by `--user`: `owner`, `writer`, `reader` (default: `owner`)
-- `-U`/`--users`: path to TSV containing emails and roles for multiple users (header optional; only one `owner` should be specified)
+- `-u`/`--user`: email of the user to share the sheet with (if a `--role` is not specified, this user will be a writer)
+- `-r`/`--role`: role of the user specified by `--user`: `writer` or `reader`
+- `-U`/`--users`: path to TSV containing emails and roles for multiple users (header optional)
 
 Three files are created in the `.cogs/` directory when running `init`:
 - `config.tsv`: COGS configuration, including the Sheet details 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ COGS takes a set of TSV files on your local file system and allows you to edit t
 Since COGS is designed to synchronize local and remote sets of tables,
 we try to follow the familiar `git` interface and workflow:
 
-- `cogs init` creates a `.cogs/` directory to store configuration data and creates a Google Sheet for the project
+- [`cogs init`](#init) creates a `.cogs/` directory to store configuration data and creates a Google Sheet for the project
 - `cogs add foo.tsv` starts tracking the `foo.tsv` table
 - `cogs push` pushes local tables to the Google Sheet
 - `cogs fetch` fetches the data from the Goolgle Sheet and stores it in `.cogs/`
 - `cogs status` summarizes the differences between tracked files and their copies in `.cogs/`
 - `cogs diff` shows detailed differences between local files and the Google Sheet
 - `cogs pull` overwrites local files with the data from the Google Sheet, if they have changed
-- `cogs delete` destroys the Google Sheet and configuration data, but leaves local files alone
+- [`cogs delete`](#delete) destroys the Google Sheet and configuration data, but leaves local files alone
 
 There is no step corresponding to `git commit`.
 
@@ -40,3 +40,13 @@ Three files are created in the `.cogs/` directory when running `init`:
 - `config.tsv`: COGS configuration, including the Sheet details 
 - `field.tsv`: Field names used in tables (contains default COGS fields)
 - `sheet.tsv`: Table names in Sheet and details (empty) - the tables correspond to tabs in the Sheet
+
+### `delete`
+
+Running `delete` reads the configuration data in `.cogs/config.tsv` to retrieve the Google Sheet ID. This Google Sheet is deleted, and the `.cogs` directory containing all project data is also removed. Any TSVs specified as tables in the Sheet are left untouched.
+
+```
+cogs delete
+```
+
+This task will fail if a COGS project has not been initialized in the working directory.

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -4,6 +4,7 @@ import pkg_resources
 import sys
 
 import cogs.init as init
+import cogs.delete as delete
 
 from argparse import ArgumentParser
 
@@ -29,10 +30,13 @@ def main():
     sp.add_argument("-t", "--title", required=True, help="Title of the project")
     sp.add_argument("-u", "--user", help="Email (user) to share all sheets with")
     sp.add_argument(
-        "-r", "--role", default="owner", help="Role for specified user (default: owner)"
+        "-r", "--role", default="writer", help="Role for specified user (default: owner)"
     )
     sp.add_argument("-U", "--users", help="TSV containing user emails and their roles")
     sp.set_defaults(func=init.run)
+
+    sp = subparsers.add_parser("delete")
+    sp.set_defaults(func=delete.run)
 
     args = parser.parse_args()
     args.func(args)

--- a/src/cogs/delete.py
+++ b/src/cogs/delete.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import sys
 
-from cogs.exceptions import DeleteError
+from cogs.exceptions import CogsError, DeleteError
 from cogs.helpers import get_client, get_config, is_cogs_project
 
 
@@ -34,8 +34,6 @@ def delete():
 
     # Get a client to perform Sheet actions
     gc = get_client(config["Credentials"])
-    if not gc:
-        raise DeleteError
 
     # Delete the Sheet
     title = config["Title"]
@@ -57,6 +55,6 @@ def run(args):
     """Wrapper for delete function."""
     try:
         delete()
-    except DeleteError as e:
+    except CogsError as e:
         print(str(e))
         sys.exit(1)

--- a/src/cogs/delete.py
+++ b/src/cogs/delete.py
@@ -4,15 +4,17 @@ import shutil
 import sys
 
 from cogs.exceptions import DeleteError
-from cogs.helpers import get_client, get_config
+from cogs.helpers import get_client, get_config, is_cogs_project
 
 
 def delete():
     """Read COGS configuration and delete the Sheet corresponding to the Google Sheet ID. Remove
     .cogs directory."""
-    config = get_config()
+    if not is_cogs_project():
+        raise DeleteError
 
-    # Validate config
+    # Get and validate the config
+    config = get_config()
     if "Google Sheet ID" not in config:
         raise DeleteError(
             "ERROR: COGS configuration does not contain 'Google Sheet ID'"
@@ -22,13 +24,15 @@ def delete():
     if "Credentials" not in config:
         raise DeleteError("ERROR: COGS configuration does not contain 'Credentials'")
 
+    # Get a client to perform Sheet actions
     gc = get_client(config["Credentials"])
     if not gc:
         raise DeleteError
 
     # Delete the Sheet
     title = config["Title"]
-    print(f"Removing COGS project '{title}'")
+    cwd = os.getcwd()
+    print(f"Removing COGS project '{title}' from {cwd}")
     try:
         gc.del_spreadsheet(config["Google Sheet ID"])
     except gspread.exceptions.APIError as e:

--- a/src/cogs/delete.py
+++ b/src/cogs/delete.py
@@ -24,6 +24,14 @@ def delete():
     if "Credentials" not in config:
         raise DeleteError("ERROR: COGS configuration does not contain 'Credentials'")
 
+    resp = input(
+        "WARNING: This task will permanently destroy the Google Sheet and all COGS data.\n"
+        "         Do you wish to proceed? [y/n]\n"
+    )
+    if resp.lower().strip() != "y":
+        print("'delete' operation stopped")
+        sys.exit(0)
+
     # Get a client to perform Sheet actions
     gc = get_client(config["Credentials"])
     if not gc:

--- a/src/cogs/delete.py
+++ b/src/cogs/delete.py
@@ -1,0 +1,50 @@
+import gspread
+import os
+import shutil
+import sys
+
+from cogs.exceptions import DeleteError
+from cogs.helpers import get_client, get_config
+
+
+def delete():
+    """Read COGS configuration and delete the Sheet corresponding to the Google Sheet ID. Remove
+    .cogs directory."""
+    config = get_config()
+
+    # Validate config
+    if "Google Sheet ID" not in config:
+        raise DeleteError(
+            "ERROR: COGS configuration does not contain 'Google Sheet ID'"
+        )
+    if "Title" not in config:
+        raise DeleteError("ERROR: COGS configuration does not contain 'Title'")
+    if "Credentials" not in config:
+        raise DeleteError("ERROR: COGS configuration does not contain 'Credentials'")
+
+    gc = get_client(config["Credentials"])
+    if not gc:
+        raise DeleteError
+
+    # Delete the Sheet
+    title = config["Title"]
+    print(f"Removing COGS project '{title}'")
+    try:
+        gc.del_spreadsheet(config["Google Sheet ID"])
+    except gspread.exceptions.APIError as e:
+        raise DeleteError(
+            f"ERROR: Unable to delete Sheet '{title}'\n" f"CAUSE: {e.response.text}"
+        )
+
+    # Remove the COGS data
+    if os.path.exists(".cogs"):
+        shutil.rmtree(".cogs")
+
+
+def run(args):
+    """Wrapper for delete function."""
+    try:
+        delete()
+    except DeleteError as e:
+        print(str(e))
+        sys.exit(1)

--- a/src/cogs/exceptions.py
+++ b/src/cogs/exceptions.py
@@ -4,3 +4,7 @@ class CogsError(Exception):
 
 class InitError(CogsError):
     """Used to indicate an error occurred during the init step."""
+
+
+class DeleteError(CogsError):
+    """Used to indicate an error occurred during the delete step."""

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -4,6 +4,8 @@ import gspread
 import os
 import re
 
+from cogs.exceptions import CogsError
+
 required_files = ["sheet.tsv", "field.tsv", "config.tsv"]
 
 
@@ -17,15 +19,15 @@ def get_client(credentials):
         print(e.response.text)
     except google.auth.exceptions.RefreshError as e:
         if "invalid_grant" in str(e):
-            print(
+            raise CogsError(
                 "ERROR: Unable to create a Client; "
                 f"account for client_email in '{credentials}' cannot be found"
             )
         else:
-            print(
+            raise CogsError(
                 f"ERROR: Unable to create a Client; cannot refresh credentials in '{credentials}'"
+                f"\nCAUSE: {str(e)}"
             )
-            print("CAUSE: " + str(e))
 
 
 def get_config():

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -4,7 +4,7 @@ import gspread
 import os
 import re
 
-required_files = ["user.tsv", "sheet.tsv", "field.tsv", "config.tsv"]
+required_files = ["sheet.tsv", "field.tsv", "config.tsv"]
 
 
 def get_client(credentials):

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -57,4 +57,4 @@ def is_email(email):
 
 def is_valid_role(role):
     """Check if a string is a valid role for use with gspread."""
-    return role in ["owner", "writer", "reader"]
+    return role in ["writer", "reader"]

--- a/src/cogs/init.py
+++ b/src/cogs/init.py
@@ -4,7 +4,7 @@ import os
 import pkg_resources
 import sys
 
-from cogs.exceptions import InitError
+from cogs.exceptions import CogsError, InitError
 from cogs.helpers import get_client, is_email, is_valid_role
 
 default_fields = [
@@ -146,8 +146,6 @@ def init(args):
 
     # Create a Client to access API
     gc = get_client(args.credentials)
-    if not gc:
-        raise InitError
 
     # Create the new Sheet
     try:
@@ -174,7 +172,7 @@ def run(args):
     """Wrapper for init function."""
     try:
         init(args)
-    except InitError as e:
+    except CogsError as e:
         print(str(e))
         if os.path.exists(".cogs"):
             os.rmdir(".cogs")

--- a/src/cogs/init.py
+++ b/src/cogs/init.py
@@ -50,7 +50,6 @@ default_fields = [
 def get_users(args):
     """Return a dict of user emails to their roles."""
     users = {}
-    has_owner = False
 
     # Single user specified
     if args.user:
@@ -62,8 +61,6 @@ def get_users(args):
         if not is_valid_role(args.role):
             raise InitError(f"ERROR: '{args.role}' is not a valid role")
         users[args.user] = args.role
-        if args.role == "owner":
-            has_owner = True
 
     # Multiple users specified
     if args.users:
@@ -91,14 +88,6 @@ def get_users(args):
                     raise InitError(
                         f"ERROR: '{role}' is not a valid role ({args.users}, line {i})"
                     )
-
-                if role == "owner":
-                    if not has_owner:
-                        has_owner = True
-                    else:
-                        raise InitError(
-                            "ERROR: There may only be one user given the 'owner' role"
-                        )
 
                 users[email] = role
                 i += 1


### PR DESCRIPTION
Resolves #3 

It looks like if the ownership of a sheet is transferred to another user, the Client cannot delete the sheet. I removed the "owner" option for roles because of this - there may be other tasks that the Client won't be able to do if it isn't the owner.

I think it should still be possible to transfer ownership to another user using `cogs share`, but this should print a big warning (e.g., COGS will not be able to perform some actions...) before proceeding.