### PR TITLE
Add share command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Since COGS is designed to synchronize local and remote sets of tables,
 we try to follow the familiar `git` interface and workflow:
 
 - [`cogs init`](#init) creates a `.cogs/` directory to store configuration data and creates a Google Sheet for the project
+- [`cogs share`](#share) shares the Google Sheet with specified users
 - `cogs add foo.tsv` starts tracking the `foo.tsv` table
 - `cogs push` pushes local tables to the Google Sheet
 - `cogs fetch` fetches the data from the Goolgle Sheet and stores it in `.cogs/`
@@ -50,3 +51,17 @@ cogs delete
 ```
 
 This task will fail if a COGS project has not been initialized in the working directory.
+
+### `share`
+
+Running `share` shares the Google Sheet with the specified user(s).
+```
+cogs share -r [reader-email] -w [writer-email]
+```
+
+There are three options:
+- `-r`/`--reader`: email of the user to give read access to
+- `-w`/`--writer`: email of the user to give write access to
+- `-o`/`--owner`: email of the user to transfer ownership to
+
+We **do not recommend** transferring ownership of the COGS project Sheet, as this will prevent COGS from performing any administrative actions (e.g., `cogs delete`). If you do transfer ownership and wish to delete the project, you should simply remove the `.cogs/` directory and then go online to Google Sheets and manually delete the project Sheet.

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -5,6 +5,7 @@ import sys
 
 import cogs.init as init
 import cogs.delete as delete
+import cogs.share as share
 
 from argparse import ArgumentParser
 
@@ -37,6 +38,12 @@ def main():
 
     sp = subparsers.add_parser("delete")
     sp.set_defaults(func=delete.run)
+
+    sp = subparsers.add_parser("share")
+    sp.add_argument("-o", "--owner", help="Email of user to transfer ownership of Sheet to")
+    sp.add_argument("-w", "--writer", help="Email of user to grant write access to")
+    sp.add_argument("-r", "--reader", help="Email of user to grant read access to")
+    sp.set_defaults(func=share.run)
 
     args = parser.parse_args()
     args.func(args)

--- a/src/cogs/delete.py
+++ b/src/cogs/delete.py
@@ -4,25 +4,14 @@ import shutil
 import sys
 
 from cogs.exceptions import CogsError, DeleteError
-from cogs.helpers import get_client, get_config, is_cogs_project
+from cogs.helpers import get_client, get_config, validate_cogs_project
 
 
 def delete():
     """Read COGS configuration and delete the Sheet corresponding to the Google Sheet ID. Remove
     .cogs directory."""
-    if not is_cogs_project():
-        raise DeleteError
-
-    # Get and validate the config
+    validate_cogs_project()
     config = get_config()
-    if "Google Sheet ID" not in config:
-        raise DeleteError(
-            "ERROR: COGS configuration does not contain 'Google Sheet ID'"
-        )
-    if "Title" not in config:
-        raise DeleteError("ERROR: COGS configuration does not contain 'Title'")
-    if "Credentials" not in config:
-        raise DeleteError("ERROR: COGS configuration does not contain 'Credentials'")
 
     resp = input(
         "WARNING: This task will permanently destroy the Google Sheet and all COGS data.\n"

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -8,6 +8,8 @@ from cogs.exceptions import CogsError
 
 required_files = ["sheet.tsv", "field.tsv", "config.tsv"]
 
+required_keys = ["Google Sheet ID", "Title", "Credentials"]
+
 
 def get_client(credentials):
     try:
@@ -37,19 +39,10 @@ def get_config():
         reader = csv.reader(f, delimiter="\t", lineterminator="\n")
         for row in reader:
             config[row[0]] = row[1]
+    for r in required_keys:
+        if r not in config:
+            raise CogsError(f"ERROR: COGS configuration does not contain key '{r}'")
     return config
-
-
-def is_cogs_project():
-    """Validate that there is a valid COGS project in this directory."""
-    if not os.path.exists(".cogs/") or not os.path.isdir(".cogs/"):
-        print("ERROR: A COGS project has not been initialized!")
-        return False
-    for r in required_files:
-        if not os.path.exists(f".cogs/{r}") or os.stat(f".cogs/{r}").st_size == 0:
-            print(f"ERROR: COGS directory is missing {r}")
-            return False
-    return True
 
 
 def is_email(email):
@@ -60,3 +53,12 @@ def is_email(email):
 def is_valid_role(role):
     """Check if a string is a valid role for use with gspread."""
     return role in ["writer", "reader"]
+
+
+def validate_cogs_project():
+    """Validate that there is a valid COGS project in this directory. If not, raise an error."""
+    if not os.path.exists(".cogs/") or not os.path.isdir(".cogs/"):
+        raise CogsError("ERROR: A COGS project has not been initialized!")
+    for r in required_files:
+        if not os.path.exists(f".cogs/{r}") or os.stat(f".cogs/{r}").st_size == 0:
+            raise CogsError(f"ERROR: COGS directory is missing {r}")

--- a/src/cogs/share.py
+++ b/src/cogs/share.py
@@ -1,0 +1,51 @@
+import gspread
+import sys
+
+from cogs.exceptions import CogsError
+from cogs.helpers import get_client, get_config, validate_cogs_project
+
+
+def share_sheet(title, sheet, user, role):
+    """Share a sheet with a user (email) as role (reader, writer, owner)"""
+    print(f"Sharing Sheet '{title}' with {user} as '{role}'")
+    try:
+        sheet.share(user, perm_type="user", role=role)
+    except gspread.exceptions.APIError as e:
+        print(f"ERROR: Unable to share Sheet '{title}'")
+        print(e.response.text)
+
+
+def share(args):
+    """Share the project Sheet with email addresses as reader, writer, or owner."""
+    validate_cogs_project()
+
+    config = get_config()
+    gc = get_client(config["Credentials"])
+
+    title = config["Title"]
+    sheet = gc.open(title)
+
+    if args.owner:
+        resp = input(
+            f"WARNING: Transferring ownership to {args.owner} will prevent COGS from performing "
+            f"administrative actions on Sheet '{title}'. Do you wish to proceed? [y/n]\n"
+        )
+        if resp.lower().strip() == "y":
+            share_sheet(title, sheet, args.owner, "owner")
+        else:
+            print(f"Ownership of Sheet '{title}' will not be transferred.")
+
+    if args.reader:
+        share_sheet(title, sheet, args.reader, "reader")
+
+    if args.writer:
+        share_sheet(title, sheet, args.writer, "writer")
+
+
+def run(args):
+    """Wrapper for share function."""
+    try:
+        share(args)
+    except CogsError as e:
+        print(str(e))
+        sys.exit(1)


### PR DESCRIPTION
Resolves #4 

### `share`

Running `share` shares the Google Sheet with the specified user(s).
```
cogs share -r [reader-email] -w [writer-email]
```

There are three options:
- `-r`/`--reader`: email of the user to give read access to
- `-w`/`--writer`: email of the user to give write access to
- `-o`/`--owner`: email of the user to transfer ownership to

We **do not recommend** transferring ownership of the COGS project Sheet, as this will prevent COGS from performing any administrative actions (e.g., `cogs delete`). If you do transfer ownership and wish to delete the project, you should simply remove the `.cogs/` directory and then go online to Google Sheets and manually delete the project Sheet.