### PR TITLE
Add `add` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cogs init -c [path-to-credentials] -t [project-title] -u [email] -r [role]
 ```
 
 Options:
-- `-c`/`--credentials`: **required**, path to Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format
+- `-c`/`--credentials`: **required**, path to [Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format
 - `-t`/`--title`: **required**, title of the project which will be used as the title of the Google Sheet
 - `-u`/`--user`: email of the user to share the sheet with (if a `--role` is not specified, this user will be a writer)
 - `-r`/`--role`: role of the user specified by `--user`: `writer` or `reader`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ we try to follow the familiar `git` interface and workflow:
 
 - [`cogs init`](#init) creates a `.cogs/` directory to store configuration data and creates a Google Sheet for the project
 - [`cogs share`](#share) shares the Google Sheet with specified users
-- `cogs add foo.tsv` starts tracking the `foo.tsv` table
+- [`cogs add foo.tsv`](#add) starts tracking the `foo.tsv` table
 - `cogs push` pushes local tables to the Google Sheet
 - `cogs fetch` fetches the data from the Goolgle Sheet and stores it in `.cogs/`
 - `cogs status` summarizes the differences between tracked files and their copies in `.cogs/`
@@ -21,6 +21,8 @@ we try to follow the familiar `git` interface and workflow:
 - [`cogs delete`](#delete) destroys the Google Sheet and configuration data, but leaves local files alone
 
 There is no step corresponding to `git commit`.
+
+---
 
 ### `init`
 
@@ -42,6 +44,10 @@ Three files are created in the `.cogs/` directory when running `init`:
 - `field.tsv`: Field names used in tables (contains default COGS fields)
 - `sheet.tsv`: Table names in Sheet and details (empty) - the tables correspond to tabs in the Sheet
 
+All other tasks will fail if a COGS project has not been initialized in the working directory.
+
+---
+
 ### `delete`
 
 Running `delete` reads the configuration data in `.cogs/config.tsv` to retrieve the Google Sheet ID. This Google Sheet is deleted, and the `.cogs` directory containing all project data is also removed. Any TSVs specified as tables in the Sheet are left untouched.
@@ -50,7 +56,7 @@ Running `delete` reads the configuration data in `.cogs/config.tsv` to retrieve 
 cogs delete
 ```
 
-This task will fail if a COGS project has not been initialized in the working directory.
+---
 
 ### `share`
 
@@ -65,3 +71,19 @@ There are three options:
 - `-o`/`--owner`: email of the user to transfer ownership to
 
 We **do not recommend** transferring ownership of the COGS project Sheet, as this will prevent COGS from performing any administrative actions (e.g., `cogs delete`). If you do transfer ownership and wish to delete the project, you should simply remove the `.cogs/` directory and then go online to Google Sheets and manually delete the project Sheet.
+
+---
+
+### `add`
+
+Running `add` will begin tracking a local TSV or CSV table. The table details (path, name/title, and description) get added to `.cogs/sheet.tsv` and all headers are added to `.cogs/field.tsv`, if they do not already exist.
+
+```
+cogs add [path] -d "[description]"
+```
+
+The `-d`/`--description` is optional.
+
+The table title is created from the path (e.g., `tables/foo.tsv` will be named `foo`). If a table with this title already exists in the project, the task will fail.
+
+This does not add the table to the Google Sheet - use `cogs push` to push all tracked local tables to the project Sheet.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,6 @@ cogs add [path] -d "[description]"
 
 The `-d`/`--description` is optional.
 
-The table title is created from the path (e.g., `tables/foo.tsv` will be named `foo`). If a table with this title already exists in the project, the task will fail.
+The table title is created from the path (e.g., `tables/foo.tsv` will be named `foo`). If a table with this title already exists in the project, the task will fail. The table name cannot be one of the COGS reserved names: `config`, `field`, `sheet`, or `user`.
 
 This does not add the table to the Google Sheet - use `cogs push` to push all tracked local tables to the project Sheet.

--- a/src/cogs/add.py
+++ b/src/cogs/add.py
@@ -1,0 +1,85 @@
+import csv
+import ntpath
+import sys
+
+from cogs.exceptions import CogsError, AddError
+from cogs.helpers import get_fields, get_tables, validate_cogs_project
+
+
+def add(args):
+    """Add a table (TSV or CSV) to the COGS project. This updates sheet.tsv and field.tsv."""
+    validate_cogs_project()
+
+    # Open the provided file and make sure we can parse it as TSV or CSV
+    if args.path.endswith(".csv"):
+        delimiter = ","
+        fmt = "CSV"
+    else:
+        delimiter = "\t"
+        fmt = "TSV"
+    with open(args.path, "r") as f:
+        try:
+            reader = csv.DictReader(f, delimiter=delimiter)
+        except csv.Error as e:
+            raise AddError(
+                f"ERROR: unable to read {args.path} as {fmt}\nCAUSE:{str(e)}"
+            )
+        headers = reader.fieldnames
+
+    # Create the sheet title from file basename
+    title = ntpath.basename(args.path).split(".")[0]
+
+    # Make sure we aren't duplicating a table
+    current_tables = get_tables()
+    if title in current_tables:
+        raise AddError(f"ERROR: '{title}' table already exists in this project")
+
+    # Maybe get a description
+    description = ""
+    if args.description:
+        description = args.description
+
+    # Get the headers to add to field.tsv if they do not exist
+    fields = get_fields()
+    update_fields = False
+    for h in headers:
+        field = h.strip().lower().replace(" ", "_")
+        if field not in fields:
+            update_fields = True
+            fields[field] = {"Label": h, "Datatype": "", "Description": ""}
+
+    # Update field.tsv if we need to
+    if update_fields:
+        with open(".cogs/field.tsv", "w") as f:
+            writer = csv.DictWriter(
+                f,
+                delimiter="\t",
+                lineterminator="\n",
+                fieldnames=["Field", "Label", "Datatype", "Description"],
+            )
+            writer.writeheader()
+            for field, items in fields.items():
+                items["Field"] = field
+                writer.writerow(items)
+
+    # Finally, add this TSV to sheet.tsv
+    with open(".cogs/sheet.tsv", "a") as f:
+        writer = csv.DictWriter(
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["ID", "Title", "Path", "Description"],
+        )
+        # ID gets filled in when we add it to the Sheet
+        writer.writerow(
+            {"ID": "", "Title": title, "Path": args.path, "Description": description}
+        )
+
+
+def run(args):
+    """Wrapper for add function."""
+    try:
+        add(args)
+    except CogsError as e:
+        print(str(e))
+        sys.exit(1)

--- a/src/cogs/add.py
+++ b/src/cogs/add.py
@@ -1,5 +1,6 @@
 import csv
 import ntpath
+import re
 import sys
 
 from cogs.exceptions import CogsError, AddError
@@ -28,6 +29,8 @@ def add(args):
 
     # Create the sheet title from file basename
     title = ntpath.basename(args.path).split(".")[0]
+    if title in ["user", "config", "sheet", "field"]:
+        raise AddError(f"ERROR: table cannot use reserved name '{title}'")
 
     # Make sure we aren't duplicating a table
     current_tables = get_tables()
@@ -43,10 +46,10 @@ def add(args):
     fields = get_fields()
     update_fields = False
     for h in headers:
-        field = h.strip().lower().replace(" ", "_")
+        field = re.sub(r"[^A-Za-z0-9]+", "_", h.lower()).strip("_")
         if field not in fields:
             update_fields = True
-            fields[field] = {"Label": h, "Datatype": "", "Description": ""}
+            fields[field] = {"Label": h, "Datatype": "cogs:text", "Description": ""}
 
     # Update field.tsv if we need to
     if update_fields:

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -6,6 +6,7 @@ import sys
 import cogs.init as init
 import cogs.delete as delete
 import cogs.share as share
+import cogs.add as add
 
 from argparse import ArgumentParser
 
@@ -24,6 +25,7 @@ def main():
     sp = subparsers.add_parser("version")
     sp.set_defaults(func=version)
 
+    # ------------------------------- init -------------------------------
     sp = subparsers.add_parser("init")
     sp.add_argument(
         "-c", "--credentials", required=True, help="Path to service account credentials"
@@ -31,19 +33,32 @@ def main():
     sp.add_argument("-t", "--title", required=True, help="Title of the project")
     sp.add_argument("-u", "--user", help="Email (user) to share all sheets with")
     sp.add_argument(
-        "-r", "--role", default="writer", help="Role for specified user (default: owner)"
+        "-r",
+        "--role",
+        default="writer",
+        help="Role for specified user (default: owner)",
     )
     sp.add_argument("-U", "--users", help="TSV containing user emails and their roles")
     sp.set_defaults(func=init.run)
 
+    # ------------------------------- delete -------------------------------
     sp = subparsers.add_parser("delete")
     sp.set_defaults(func=delete.run)
 
+    # ------------------------------- share -------------------------------
     sp = subparsers.add_parser("share")
-    sp.add_argument("-o", "--owner", help="Email of user to transfer ownership of Sheet to")
+    sp.add_argument(
+        "-o", "--owner", help="Email of user to transfer ownership of Sheet to"
+    )
     sp.add_argument("-w", "--writer", help="Email of user to grant write access to")
     sp.add_argument("-r", "--reader", help="Email of user to grant read access to")
     sp.set_defaults(func=share.run)
+
+    # ------------------------------- add -------------------------------
+    sp = subparsers.add_parser("add")
+    sp.add_argument("path", help="Path to TSV or CSV to add to COGS project")
+    sp.add_argument("-d", "--description", help="Description of table to add to Sheet")
+    sp.set_defaults(func=add.run)
 
     args = parser.parse_args()
     args.func(args)

--- a/src/cogs/exceptions.py
+++ b/src/cogs/exceptions.py
@@ -8,3 +8,7 @@ class InitError(CogsError):
 
 class DeleteError(CogsError):
     """Used to indicate an error occurred during the delete step."""
+
+
+class AddError(CogsError):
+    """Used to indicate an error occurred during the add step."""

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -45,6 +45,30 @@ def get_config():
     return config
 
 
+def get_fields():
+    """Get the current fields in this project from field.tsv."""
+    fields = {}
+    with open(".cogs/field.tsv", "r") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            field = row["Field"]
+            del row["Field"]
+            fields[field] = row
+    return fields
+
+
+def get_tables():
+    """Get the current tables in this project from sheet.tsv."""
+    tables = {}
+    with open(".cogs/sheet.tsv", "r") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            title = row["Title"]
+            del row["Title"]
+            tables[title] = row
+    return tables
+
+
 def is_email(email):
     """Check if a string matches a general email pattern (user@domain.tld)"""
     return re.match(r"^[-.\w]+@[-\w]+\.[-\w]+$", email)


### PR DESCRIPTION
Resolves #6 

Note that the table ID is not added in `sheet.tsv`. This is how we know it hasn't been pushed to the Google Sheet yet. Once it's pushed, it will get an ID.

### `add`

Running `add` will begin tracking a local TSV or CSV table. The table details (path, name/title, and description) get added to `.cogs/sheet.tsv` and all headers are added to `.cogs/field.tsv`, if they do not already exist.

```
cogs add [path] -d "[description]"
```

The `-d`/`--description` is optional.

The table title is created from the path (e.g., `tables/foo.tsv` will be named `foo`). If a table with this title already exists in the project, the task will fail.

This does not add the table to the Google Sheet - use `cogs push` to push all tracked local tables to the project Sheet.