### PR TITLE
Local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# VSCode project settings
+.vscode
+
 # mkdocs documentation
 /site
 
@@ -130,3 +133,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# When testing in source, exclude .cogs
+.cogs

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ There is no step corresponding to `git commit`.
 
 ---
 
+### Getting started development
+
+To be able to use the local code without having to install it (this makes the development easier): 
+
+On Linux:
+```
+$ virtualenv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
+$ export PYTHONPATH=$PYTHONPATH:$PWD/src
+$ python src/cogs/cli.py
+```
+
 ### `init`
 
 Running `init` creates a `.cogs` directory containing configuration data. This also creates a new Google Sheets spreadsheet and stores the ID. Optionally, this new sheet may be shared with users.

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -12,9 +12,17 @@ import cogs.push as push
 from argparse import ArgumentParser
 
 
+def get_version():
+    try:
+        version = pkg_resources.require("COGS")[0].version
+    except pkg_resources.DistributionNotFound:
+        version = "developer-version"
+    return version
+
+
 def version(args):
     """Print COGS version information."""
-    v = pkg_resources.require("COGS")[0].version
+    v = get_version()
     print(f"COGS version {v}")
     sys.exit(0)
 

--- a/src/cogs/init.py
+++ b/src/cogs/init.py
@@ -6,6 +6,8 @@ import sys
 
 from cogs.exceptions import CogsError, InitError
 from cogs.helpers import get_client, is_email, is_valid_role
+from cogs.cli import get_version
+
 
 default_fields = [
     {
@@ -93,7 +95,6 @@ def get_users(args):
                 i += 1
     return users
 
-
 def write_data(args, sheet):
     """Create COGS data files: config.tsv, sheet.tsv, and field.tsv."""
     # Store COGS configuration
@@ -101,7 +102,7 @@ def write_data(args, sheet):
         writer = csv.DictWriter(
             f, delimiter="\t", lineterminator="\n", fieldnames=["Key", "Value"]
         )
-        v = pkg_resources.require("COGS")[0].version
+        v = get_version()
         writer.writerow({"Key": "COGS", "Value": "https://github.com/ontodev/cogs"})
         writer.writerow({"Key": "COGS Version", "Value": v})
         writer.writerow({"Key": "Credentials", "Value": args.credentials})


### PR DESCRIPTION
Allow for local use of COGS without having to install the package.

Another thing that could be done, but may differ on different platforms is to get the git reference of the current commit. But I don't believe it is really useful.