### PR TITLE
Add fetch function & add better logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,24 @@ we try to follow the familiar `git` interface and workflow:
 - [`cogs add foo.tsv`](#add) starts tracking the `foo.tsv` table as a sheet
 - `cogs rm foo.tsv` stops tracking the `foo.tsv` table as a sheet
 - [`cogs push`](#push) pushes changes to local sheets to the project spreadsheet
-- `cogs fetch` fetches the data from the spreadsheet and stores it in `.cogs/`
+- [`cogs fetch`](#fetch) fetches the data from the spreadsheet and stores it in `.cogs/`
+- `cogs mv` updates the path to the local version of a spreadsheet
 - `cogs status` summarizes the differences between tracked files and their copies in `.cogs/`
 - `cogs diff` shows detailed differences between local files and the spreadsheet
 - `cogs pull` overwrites local files with the data from the spreadsheet, if they have changed
 - [`cogs delete`](#delete) destroys the spreadsheet and configuration data, but leaves local files alone
 
 There is no step corresponding to `git commit`.
+
+## Logging
+
+To print info-level logging messages (error and critical level messages are always printed), run any command with the `-v`/`--verbose` flag:
+
+```
+cogs [command & opts] -v
+```
+
+Otherwise, most commands succeed silently.
 
 ## Definitions
 
@@ -101,7 +112,7 @@ We **do not recommend** transferring ownership of the COGS project spreadsheet, 
 
 ### `add`
 
-Running `add` will begin tracking a local TSV or CSV table. The table details (path, name/title, and description) get added to `.cogs/sheet.tsv` and all headers are added to `.cogs/field.tsv`, if they do not already exist.
+Running `add` will begin tracking a local TSV or CSV table. The table details (path, name/title, and description) get added to `.cogs/sheet.tsv` and all headers are added to `.cogs/field.tsv`, if they do not already exist with the default datatype of `cogs:text` (text string).
 
 ```
 cogs add [path] -d "[description]"
@@ -122,3 +133,19 @@ Running `push` will sync the spreadsheet with your local changes. This includes 
 ```
 cogs push
 ```
+
+---
+
+### `fetch`
+
+Running `fetch` will sync the local `.cogs/` directory with all remote spreadsheet changes.
+
+```
+cogs fetch
+```
+
+This will download all sheets in the spreadsheet to that directory as `{sheet-title}.tsv` - this will overwrite the existing sheets in `.cogs/`, but will not overwrite the local versions specified by their path. As the sheets are downloaded, the fields are checked against existing fields in `.cogs/field.tsv` and any new fields are added with the default datatype of `cogs:text` (text string). Any sheets that have been added with `add` and then pushed to the remote sheet with `push` will be given their IDs in `.cogs/sheet.tsv`.
+
+If a new sheet has been added to the Google spreadsheet, this sheet will be downloaded and added to `.cogs/sheet.tsv`. The default path for pulling changes will be the current working directory (the same directory as `.cogs/` is in). This path can be updated with `cogs mv`.
+
+To sync the local version of sheets with the data in `.cogs/`, run `cogs pull`.

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -9,6 +9,7 @@ import cogs.share as share
 import cogs.add as add
 import cogs.push as push
 import cogs.open as open
+import cogs.fetch as fetch
 
 from argparse import ArgumentParser
 
@@ -22,13 +23,15 @@ def version(args):
 
 def main():
     parser = ArgumentParser()
+    global_parser = ArgumentParser(add_help=False)
+    global_parser.add_argument("-v", "--verbose", help="Print logging", action="store_true")
     subparsers = parser.add_subparsers(required=True, dest="cmd")
 
-    sp = subparsers.add_parser("version")
+    sp = subparsers.add_parser("version", parents=[global_parser])
     sp.set_defaults(func=version)
 
     # ------------------------------- init -------------------------------
-    sp = subparsers.add_parser("init")
+    sp = subparsers.add_parser("init", parents=[global_parser])
     sp.add_argument(
         "-c", "--credentials", required=True, help="Path to service account credentials"
     )
@@ -41,29 +44,33 @@ def main():
     sp.set_defaults(func=init.run)
 
     # ------------------------------- delete -------------------------------
-    sp = subparsers.add_parser("delete")
+    sp = subparsers.add_parser("delete", parents=[global_parser])
     sp.set_defaults(func=delete.run)
 
     # ------------------------------- share -------------------------------
-    sp = subparsers.add_parser("share")
+    sp = subparsers.add_parser("share", parents=[global_parser])
     sp.add_argument("-o", "--owner", help="Email of user to transfer ownership of spreadsheet to")
     sp.add_argument("-w", "--writer", help="Email of user to grant write access to")
     sp.add_argument("-r", "--reader", help="Email of user to grant read access to")
     sp.set_defaults(func=share.run)
 
     # ------------------------------- add -------------------------------
-    sp = subparsers.add_parser("add")
+    sp = subparsers.add_parser("add", parents=[global_parser])
     sp.add_argument("path", help="Path to TSV or CSV to add to COGS project")
     sp.add_argument("-d", "--description", help="Description of sheet to add to spreadsheet")
     sp.set_defaults(func=add.run)
 
     # ------------------------------- push -------------------------------
-    sp = subparsers.add_parser("push")
+    sp = subparsers.add_parser("push", parents=[global_parser])
     sp.set_defaults(func=push.run)
 
     # ------------------------------- open -------------------------------
-    sp = subparsers.add_parser("open")
+    sp = subparsers.add_parser("open", parents=[global_parser])
     sp.set_defaults(func=open.run)
+
+    # ------------------------------- fetch -------------------------------
+    sp = subparsers.add_parser("fetch", parents=[global_parser])
+    sp.set_defaults(func=fetch.run)
 
     args = parser.parse_args()
     args.func(args)

--- a/src/cogs/exceptions.py
+++ b/src/cogs/exceptions.py
@@ -12,3 +12,7 @@ class DeleteError(CogsError):
 
 class AddError(CogsError):
     """Used to indicate an error occurred during the add step."""
+
+
+class FetchError(CogsError):
+    """Used to indicate an error occurred during the fetch step."""

--- a/src/cogs/fetch.py
+++ b/src/cogs/fetch.py
@@ -94,7 +94,7 @@ def fetch(args):
         details = {
             "ID": sid,
             "Title": sheet_title,
-            "Path": f".cogs/{sheet_title}.tsv",
+            "Path": f"{sheet_title}.tsv",
             "Description": "",
         }
         all_sheets.append(details)

--- a/src/cogs/fetch.py
+++ b/src/cogs/fetch.py
@@ -24,6 +24,7 @@ def get_remote_sheets(sheets):
                 f"cannot export remote sheet with the reserved name '{sheet.title}'"
             )
         remote_sheets[sheet.title] = sheet.id
+    return remote_sheets
 
 
 def fetch(args):

--- a/src/cogs/fetch.py
+++ b/src/cogs/fetch.py
@@ -1,0 +1,120 @@
+import csv
+import logging
+import re
+import sys
+
+from cogs.exceptions import CogsError, FetchError
+from cogs.helpers import (
+    get_config,
+    get_client,
+    get_fields,
+    get_sheets,
+    set_logging,
+    validate_cogs_project,
+)
+
+
+def get_remote_sheets(sheets):
+    """Retrieve a map of sheet title -> sheet ID from the spreadsheet."""
+    # Validate sheet titles before downloading anything
+    remote_sheets = {}
+    for sheet in sheets:
+        if sheet.title in ["user", "config", "sheet", "field"]:
+            raise FetchError(
+                f"cannot export remote sheet with the reserved name '{sheet.title}'"
+            )
+        remote_sheets[sheet.title] = sheet.id
+
+
+def fetch(args):
+    """Fetch all sheets from project spreadsheet to .cogs/ directory."""
+    set_logging(args.verbose)
+    validate_cogs_project()
+
+    config = get_config()
+    client = get_client(config["Credentials"])
+    title = config["Title"]
+    spreadsheet = client.open(title)
+
+    # Get existing fields to see if we need to add new fields
+    fields = get_fields()
+    update_fields = False
+
+    # Get the remote sheets from spreadsheet
+    sheets = spreadsheet.worksheets()
+    remote_sheets = get_remote_sheets(sheets)
+
+    # Export the sheets as TSV to .cogs/ (while checking the fieldnames)
+    for sheet in sheets:
+        logging.info(f"Downloading '{sheet.title}'")
+        with open(f".cogs/{sheet.title}.tsv", "w") as f:
+            lines = sheet.get_all_values()
+            writer = csv.writer(f, delimiter="\t", lineterminator="\n")
+            writer.writerows(lines)
+
+            # Check for new fields in sheet header
+            for h in lines[0]:
+                field = re.sub(r"[^A-Za-z0-9]+", "_", h.lower()).strip("_")
+                if field not in fields:
+                    update_fields = True
+                    fields[field] = {"Label": h, "Datatype": "cogs:text", "Description": ""}
+
+    # Update field.tsv if we need to
+    if update_fields:
+        with open(".cogs/field.tsv", "w") as f:
+            writer = csv.DictWriter(
+                f,
+                delimiter="\t",
+                lineterminator="\n",
+                fieldnames=["Field", "Label", "Datatype", "Description"],
+            )
+            writer.writeheader()
+            for field, items in fields.items():
+                items["Field"] = field
+                writer.writerow(items)
+
+    # Update local sheets with new IDs
+    local_sheets = get_sheets()
+    all_sheets = []
+    for sheet_title, details in local_sheets.items():
+        if sheet_title in remote_sheets:
+            sid = remote_sheets[sheet_title]
+            details["ID"] = sid
+        details["Title"] = sheet_title
+        all_sheets.append(details)
+
+    # Get just the remote sheets that are not in local sheets
+    new_sheets = {
+        sheet_title: sid
+        for sheet_title, sid in remote_sheets.items()
+        if sheet_title not in local_sheets
+    }
+    for sheet_title, sid in new_sheets.items():
+        logging.info(f"new sheet '{sheet_title}' added to project")
+        details = {
+            "ID": sid,
+            "Title": sheet_title,
+            "Path": f".cogs/{sheet_title}.tsv",
+            "Description": "",
+        }
+        all_sheets.append(details)
+
+    # Then update sheet.tsv
+    with open(".cogs/sheet.tsv", "w") as f:
+        writer = csv.DictWriter(
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["ID", "Title", "Path", "Description"],
+        )
+        writer.writeheader()
+        writer.writerows(all_sheets)
+
+
+def run(args):
+    """Wrapper for fetch function."""
+    try:
+        fetch(args)
+    except CogsError as e:
+        logging.critical(str(e))
+        sys.exit(1)

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -1,6 +1,7 @@
 import csv
 import google.auth.exceptions
 import gspread
+import logging
 import os
 import pkg_resources
 import re
@@ -26,17 +27,17 @@ def get_client(credentials):
         gc.login()
         return gc
     except gspread.exceptions.APIError as e:
-        print(f"ERROR: Unable to create a Client from credentials '{credentials}'")
+        print(f"Unable to create a Client from credentials '{credentials}'")
         print(e.response.text)
     except google.auth.exceptions.RefreshError as e:
         if "invalid_grant" in str(e):
             raise CogsError(
-                "ERROR: Unable to create a Client; "
+                "Unable to create a Client; "
                 f"account for client_email in '{credentials}' cannot be found"
             )
         else:
             raise CogsError(
-                f"ERROR: Unable to create a Client; cannot refresh credentials in '{credentials}'"
+                f"Unable to create a Client; cannot refresh credentials in '{credentials}'"
                 f"\nCAUSE: {str(e)}"
             )
 
@@ -58,7 +59,7 @@ def get_config():
             config[row[0]] = row[1]
     for r in required_keys:
         if r not in config:
-            raise CogsError(f"ERROR: COGS configuration does not contain key '{r}'")
+            raise CogsError(f"COGS configuration does not contain key '{r}'")
     return config
 
 
@@ -96,10 +97,17 @@ def is_valid_role(role):
     return role in ["writer", "reader"]
 
 
+def set_logging(verbose):
+    if verbose:
+        logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    else:
+        logging.basicConfig(level=logging.ERROR, format="%(levelname)s: %(message)s")
+
+
 def validate_cogs_project():
     """Validate that there is a valid COGS project in this directory. If not, raise an error."""
     if not os.path.exists(".cogs/") or not os.path.isdir(".cogs/"):
-        raise CogsError("ERROR: A COGS project has not been initialized!")
+        raise CogsError("A COGS project has not been initialized!")
     for r in required_files:
         if not os.path.exists(f".cogs/{r}") or os.stat(f".cogs/{r}").st_size == 0:
-            raise CogsError(f"ERROR: COGS directory is missing {r}")
+            raise CogsError(f"COGS directory is missing {r}")

--- a/src/cogs/open.py
+++ b/src/cogs/open.py
@@ -1,12 +1,13 @@
-import gspread
+import logging
 import sys
 
 from cogs.exceptions import CogsError
-from cogs.helpers import get_client, get_config, validate_cogs_project
+from cogs.helpers import get_config, set_logging, validate_cogs_project
 
 
 def openSheet(args):
     """Display the URL of the spreadsheet."""
+    set_logging(args.verbose)
     validate_cogs_project()
 
     config = get_config()
@@ -20,5 +21,5 @@ def run(args):
     try:
         openSheet(args)
     except CogsError as e:
-        print(str(e))
+        logging.critical(str(e))
         sys.exit(1)

--- a/src/cogs/share.py
+++ b/src/cogs/share.py
@@ -1,22 +1,23 @@
 import gspread
+import logging
 import sys
 
 from cogs.exceptions import CogsError
-from cogs.helpers import get_client, get_config, validate_cogs_project
+from cogs.helpers import get_client, get_config, set_logging, validate_cogs_project
 
 
 def share_spreadsheet(title, spreadsheet, user, role):
     """Share a sheet with a user (email) as role (reader, writer, owner)"""
-    print(f"Sharing spreadsheet '{title}' with {user} as '{role}'")
+    logging.info(f"Sharing spreadsheet '{title}' with {user} as '{role}'")
     try:
         spreadsheet.share(user, perm_type="user", role=role)
     except gspread.exceptions.APIError as e:
-        print(f"ERROR: Unable to share spreadsheet '{title}'")
-        print(e.response.text)
+        logging.error(f"Unable to share spreadsheet '{title}'\n" + e.response.text)
 
 
 def share(args):
     """Share the project spreadsheet with email addresses as reader, writer, or owner."""
+    set_logging(args.verbose)
     validate_cogs_project()
 
     config = get_config()
@@ -47,5 +48,5 @@ def run(args):
     try:
         share(args)
     except CogsError as e:
-        print(str(e))
+        logging.critical(str(e))
         sys.exit(1)


### PR DESCRIPTION
Resolves #5

Also, instead of printing everything, change messages to use `logging`.

## Logging

To print info- and warn-level logging messages (error- and critical-level messages are always printed), run any command with the `-v`/`--verbose` flag:

```
cogs [command & opts] -v
```

Otherwise, most commands succeed silently.

---

### `fetch`

Running `fetch` will sync the local `.cogs/` directory with all remote spreadsheet changes.

```
cogs fetch
```

This will download all sheets in the spreadsheet to that directory as `{sheet-title}.tsv` - this will overwrite the existing sheets in `.cogs/`, but will not overwrite the local versions specified by their path. As the sheets are downloaded, the fields are checked against existing fields in `.cogs/field.tsv` and any new fields are added with the default datatype of `cogs:text` (text string). Any sheets that have been added with `add` and then pushed to the remote sheet with `push` will be given their IDs in `.cogs/sheet.tsv`.

If a new sheet has been added to the Google spreadsheet, this sheet will be downloaded and added to `.cogs/sheet.tsv`. The default path for pulling changes will be the current working directory (the same directory as `.cogs/` is in). This path can be updated with `cogs mv`.

To sync the local version of sheets with the data in `.cogs/`, run `cogs pull`.