### PR TITLE
Add diff function

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ By default, this will display all files with changes. If you wish to just see th
 cogs diff path1.tsv path2.tsv ...
 ```
 
-`diff` opens a responsive scrolling window. To scroll down, press the down arrow. To scroll up, press the up arrow. For large files with many columns, you can also scroll to the right with the right arrow and back to the left with the left arrow.
+`diff` opens a responsive scrolling window. To scroll down, press the down arrow. To scroll up, press the up arrow (see all navigation below). For large files with many columns, you can also scroll to the right with the right arrow and back to the left with the left arrow.
 
 The start of a diff for a sheet begins in bold with the file name (local and remote versions).
 
@@ -194,6 +194,10 @@ old text -> new text
 If a sheet has been newly created or deleted, these changes will not appear in `diff`. Instead, use `cogs status`.
 
 To navigate the diff:
+* &#8593;: move one line up
+* &#8595;: move one line down
+* &#8594;: move 20 characters right
+* &#8592;: move 20 characters left
 * `q`: quit
 * `t`: go to top (first line)
 * `b`: go to bottom (last line)

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ By default, this will display all files with changes. If you wish to just see th
 cogs diff path1.tsv path2.tsv ...
 ```
 
-`diff` opens a responsive scrolling window. To scroll down, press the down arrow. To scroll up, press the up arrow. For large files with many columns, you can also scroll to the right with the right arrow and back to the left with the left arrow. To exit the window, press `q`.
+`diff` opens a responsive scrolling window. To scroll down, press the down arrow. To scroll up, press the up arrow. For large files with many columns, you can also scroll to the right with the right arrow and back to the left with the left arrow.
 
 The start of a diff for a sheet begins in bold with the file name (local and remote versions).
 
@@ -192,3 +192,10 @@ old text -> new text
 ```
 
 If a sheet has been newly created or deleted, these changes will not appear in `diff`. Instead, use `cogs status`.
+
+To navigate the diff:
+* `q`: quit
+* `t`: go to top (first line)
+* `b`: go to bottom (last line)
+* `r`: go to rightmost characters (last column)
+* `l`: to to leftmost characters (first column)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ we try to follow the familiar `git` interface and workflow:
 - [`cogs fetch`](#fetch) fetches the data from the spreadsheet and stores it in `.cogs/`
 - `cogs mv` updates the path to the local version of a spreadsheet
 - `cogs status` summarizes the differences between tracked files and their copies in `.cogs/`
-- `cogs diff` shows detailed differences between local files and the spreadsheet
+- [`cogs diff`](#diff) shows detailed differences between local files and the spreadsheet
 - `cogs pull` overwrites local files with the data from the spreadsheet, if they have changed
 - [`cogs delete`](#delete) destroys the spreadsheet and configuration data, but leaves local files alone
 
@@ -149,3 +149,35 @@ This will download all sheets in the spreadsheet to that directory as `{sheet-ti
 If a new sheet has been added to the Google spreadsheet, this sheet will be downloaded and added to `.cogs/sheet.tsv`. The default path for pulling changes will be the current working directory (the same directory as `.cogs/` is in). This path can be updated with `cogs mv`.
 
 To sync the local version of sheets with the data in `.cogs/`, run `cogs pull`.
+
+---
+
+### `diff`
+
+Running `diff` will display all file changes between local and remote sheets after running `cogs fetch`.
+
+```
+cogs diff
+```
+
+By default, this will display all files with changes. If you wish to just see the changes for one or more paths, you can provide those paths:
+
+```
+cogs diff path1.tsv path2.tsv ...
+```
+
+`diff` opens a responsive scrolling window. To scroll down, press the down arrow. To scroll up, press the up arrow. For large files with many columns, you can also scroll to the right with the right arrow and back to the left with the left arrow. To exit the window, press `q`.
+
+The start of a diff for a sheet begins in bold with the file name (local and remote versions).
+
+The displayed text below has formatting for changes between the local and remote sheets:
+* Lines that have been _removed_ from the remote version of the sheet are in red text and begin with `---`.
+* Lines that have been _added_ to the local version of the sheet are in green text and begin with `+++`.
+* Lines that have been _changed_ between the remote and local versions are in blue text and begin with `->`.
+
+In cells with _changed_ values, the cell is formatted as so:
+```
+old text -> new text
+```
+
+If a sheet has been newly created or deleted, these changes will not appear in `diff`. Instead, use `cogs status`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 black
+daff
 flake8
 google
 gspread
 pytest
+tabulate
+termcolor

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ google
 gspread
 pytest
 tabulate
-termcolor

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -10,6 +10,7 @@ import cogs.add as add
 import cogs.push as push
 import cogs.open as open
 import cogs.fetch as fetch
+import cogs.diff as diff
 
 from argparse import ArgumentParser
 
@@ -71,6 +72,11 @@ def main():
     # ------------------------------- fetch -------------------------------
     sp = subparsers.add_parser("fetch", parents=[global_parser])
     sp.set_defaults(func=fetch.run)
+
+    # ------------------------------- diff -------------------------------
+    sp = subparsers.add_parser("diff", parents=[global_parser])
+    sp.set_defaults(func=diff.run)
+    sp.add_argument("paths", nargs="*", help="Paths to local sheets to diff")
 
     args = parser.parse_args()
     args.func(args)

--- a/src/cogs/diff.py
+++ b/src/cogs/diff.py
@@ -49,9 +49,6 @@ def get_lines(sheets):
                         lines.append((t, curses.color_pair(3)))
                     else:
                         lines.append((t, None))
-
-        # TODO - handle created and deleted sheets based on add/rm
-        #      - and based on new sheets from fetch
     return lines
 
 

--- a/src/cogs/diff.py
+++ b/src/cogs/diff.py
@@ -1,0 +1,167 @@
+import curses
+import logging
+import os
+import sys
+import tabulate
+
+from cogs.exceptions import CogsError, DiffError
+from cogs.helpers import get_diff, get_sheets, set_logging, validate_cogs_project
+
+
+def get_lines(sheets):
+    """Return the lines for a diff as an array of pairs (text, formatting)."""
+    lines = []
+    for sheet_title, details in sheets.items():
+        remote = f".cogs/{sheet_title}.tsv"
+        local = details["Path"]
+        if os.path.exists(local) and os.path.exists(remote):
+            sheet_diff = get_diff(local, remote)
+            if len(sheet_diff) > 1:
+                lines.append(("", None))
+                lines.append((f"--- {remote} (remote)", curses.A_BOLD))
+                lines.append((f"+++ {local} (local)", curses.A_BOLD))
+                has_col_changes = True
+                for c in set(sheet_diff[1]):
+                    if c != "+++" and c != "---":
+                        has_col_changes = False
+                        break
+                if has_col_changes:
+                    hs1 = sheet_diff.pop(0)
+                    hs2 = sheet_diff.pop(0)
+                    headers = []
+                    for idx in range(0, len(hs1)):
+                        h1 = hs1[idx]
+                        if h1 == "!":
+                            headers.append("")
+                        else:
+                            h2 = hs2[idx]
+                            headers.append(f"{h1}\n{h2}")
+                else:
+                    headers = sheet_diff.pop(0)
+                    headers[0] = ""
+                tab = tabulate.tabulate(sheet_diff, headers=headers)
+                for t in tab.split("\n"):
+                    if t.startswith("+++"):
+                        lines.append((t, curses.color_pair(2)))
+                    elif t.startswith("---") and not t.endswith("---"):
+                        lines.append((t, curses.color_pair(1)))
+                    elif t.startswith("->"):
+                        lines.append((t, curses.color_pair(3)))
+                    else:
+                        lines.append((t, None))
+
+        # TODO - handle created and deleted sheets based on add/rm
+        #      - and based on new sheets from fetch
+    return lines
+
+
+def diff(args):
+    """Start a window with dynamic response to display the diffs for all provided paths."""
+    set_logging(args.verbose)
+    validate_cogs_project()
+
+    sheets = get_sheets()
+    paths = [details["Path"] for details in sheets.values()]
+    if args.paths:
+        for p in args.paths:
+            if p not in paths:
+                raise DiffError(f"sheet '{p}' is not part of the current project")
+        sheets = {
+            sheet_title: details
+            for sheet_title, details in sheets.items()
+            if details["Path"] in args.paths
+        }
+
+    # Init the curses screen
+    stdscr = curses.initscr()
+
+    # Set screen/curses options
+    curses.noecho()
+    curses.cbreak()
+    stdscr.keypad(True)
+    stdscr.scrollok(True)
+
+    # Set the color pairs
+    curses.start_color()
+    curses.use_default_colors()
+    curses.init_pair(1, curses.COLOR_RED, -1)
+    curses.init_pair(2, curses.COLOR_GREEN, -1)
+    curses.init_pair(3, curses.COLOR_CYAN, -1)
+
+    # Get lines for the diff display
+    lines = get_lines(sheets)
+
+    try:
+        stdscr.clear()
+        stdscr.refresh()
+
+        # Get the size of the window
+        rows, cols = stdscr.getmaxyx()
+        rows = rows - 1
+
+        # Tracking for current x and y
+        # Row is y and col position is x
+        y = 0
+        x = 0
+        eof = False
+
+        # Display lines
+        while True:
+            # Add a message when we hit the EOF
+            if eof or rows > len(lines) - 2:
+                stdscr.addstr(
+                    rows, 0, "~ end of diff", curses.color_pair(3) | curses.A_BOLD
+                )
+
+            # Get the lines to display based on current top line & size of window
+            disp_lines = lines[y : y + rows]
+
+            # Display these lines, only printing ot the size of the cols (x)
+            for i in range(0, len(disp_lines)):
+                text = disp_lines[i][0][x: cols + x]
+                fmt = disp_lines[i][1]
+                if fmt:
+                    stdscr.addstr(i, 0, text + "\n", fmt)
+                else:
+                    stdscr.addstr(i, 0, text + "\n")
+
+            # Get user input
+            k = stdscr.getch()
+            if k == ord("q"):
+                # Exit
+                return
+            elif k == curses.KEY_DOWN:
+                if not eof and not rows > len(lines) - 2:
+                    y += 1
+                    if y + rows == len(lines) + 1:
+                        eof = True
+                continue
+            elif k == curses.KEY_UP:
+                if eof:
+                    eof = False
+                if y > 0:
+                    y -= 1
+                continue
+            elif k == curses.KEY_RIGHT:
+                x += 20
+                continue
+            elif k == curses.KEY_LEFT:
+                if x > 0:
+                    x -= 20
+                continue
+
+    finally:
+        # Clean up window
+        stdscr.keypad(False)
+        curses.nocbreak()
+        curses.echo()
+        curses.endwin()
+
+
+def run(args):
+    """Wrapper for diff function."""
+    try:
+        diff(args)
+    except CogsError as e:
+        logging.critical(str(e))
+        sys.exit(1)

--- a/src/cogs/diff.py
+++ b/src/cogs/diff.py
@@ -3,7 +3,6 @@ import logging
 import os
 import sys
 import tabulate
-import termcolor
 
 from cogs.exceptions import CogsError, DiffError
 from cogs.helpers import get_diff, get_sheets, set_logging, validate_cogs_project

--- a/src/cogs/diff.py
+++ b/src/cogs/diff.py
@@ -9,6 +9,7 @@ from cogs.helpers import get_diff, get_sheets, set_logging, validate_cogs_projec
 
 
 def close_screen(stdscr):
+    """Reset curses options and end window."""
     # Clean up window
     stdscr.keypad(False)
     curses.nocbreak()
@@ -97,6 +98,7 @@ def diff(args):
     # Get lines for the diff display
     lines = get_lines(sheets)
     if not lines:
+        # Nothing to display
         close_screen(stdscr)
         print(
             "Local sheets are up to date with remote sheets (nothing to push or pull).\n"

--- a/src/cogs/exceptions.py
+++ b/src/cogs/exceptions.py
@@ -16,3 +16,7 @@ class AddError(CogsError):
 
 class FetchError(CogsError):
     """Used to indicate an error occurred during the fetch step."""
+
+
+class DiffError(CogsError):
+    """Used to indicate an error occurred during the diff step."""

--- a/src/cogs/fetch.py
+++ b/src/cogs/fetch.py
@@ -24,6 +24,7 @@ def get_remote_sheets(sheets):
                 f"cannot export remote sheet with the reserved name '{sheet.title}'"
             )
         remote_sheets[sheet.title] = sheet.id
+    return remote_sheets
 
 
 def fetch(args):


### PR DESCRIPTION
Wait on #31
Resolves #9 

This is a first pass at an interactive screen to better display large tables using `curses`. Scrolling up, down, left, and right works (or at least it should :smile: ). It's still a little finicky but I think it's working for the most part.

### `diff`

Running `diff` will display all file changes between local and remote sheets after running `cogs fetch`.

```
cogs diff
```

By default, this will display all files with changes. If you wish to just see the changes for one or more paths, you can provide those paths:

```
cogs diff path1.tsv path2.tsv ...
```

`diff` opens a responsive scrolling window. To scroll down, press the down arrow. To scroll up, press the up arrow. For large files with many columns, you can also scroll to the right with the right arrow and back to the left with the left arrow. To exit the window, press `q`.

The start of a diff for a sheet begins in bold with the file name (local and remote versions).

The displayed text below has formatting for changes between the local and remote sheets:
* Lines that have been _removed_ from the remote version of the sheet are in red text and begin with `---`.
* Lines that have been _added_ to the local version of the sheet are in green text and begin with `+++`.
* Lines that have been _changed_ between the remote and local versions are in blue text and begin with `->`.

In cells with _changed_ values, the cell is formatted as so:
```
old text -> new text
```

If a sheet has been newly created or deleted, these changes will not appear in `diff`. Instead, use `cogs status`.