### PR TITLE
Add `status` command & code clean-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,12 @@ cogs status
 ```
 
 There are five kinds of statuses (note that any changes to the remote spreadsheet will not be accounted for until you run `cogs fetch`)
-* **Changed**: the sheet exists both locally and remotely (cached in the `.cogs` directory), but there is a difference between the local and cached version
+* **Modified locally**: the sheet exists both locally and remotely, but the local version has been edited since the last time `cogs fetch` or `cogs push` were run
     * use `cogs diff [path]` to see details
-    * use `cogs push` to sync local changes to remote version (overwriting any changes to remote not yet pulled)
-    * OR use `cogs pull` to sync remote changes to local version (overwriting any changes to local not yet pushed)
+	* use `cogs push` to sync local changes to remote version (overwriting any changes to remote not yet pulled)
+* **Modified remotely**: the sheet exists both locally and remotely, but `cogs fetch` has been run and returned a modified sheet since the last time the local version was edited
+    * use `cogs diff [path]` to see details
+    * use `cogs pull` to sync remote changes to local version (overwriting any changes to local not yet pushed)
 * **Added locally**: the sheet exists locally and has been added to tracking, but is not yet pushed to the remote spreadsheet
     * use `cogs push` to add the sheet to the remote spreadsheet
 * **Added remotely**: the sheet exists remotely and has been added to tracking, but is not yet pulled to a local copy

--- a/README.md
+++ b/README.md
@@ -213,8 +213,15 @@ cogs status
 ```
 
 There are five kinds of statuses (note that any changes to the remote spreadsheet will not be accounted for until you run `cogs fetch`)
-* **Changed**: the sheet exists both locally and remotely (cached in the `.cogs` directory), but there is a difference between the local and cached version (use `cogs diff [path]` to see details; depending on if you want the local or remote changes synced, use `cogs push` or `cogs pull`, respectively)
-* **Added locally**: the sheet exists locally and has been added to tracking, but is not yet pushed to the remote spreadsheet (use `cogs push` to sync)
-* **Added remotely**: the sheet exists remotely and has been added to tracking, but is not yet pulled to a local copy (use `cogs pull` to sync)
-* **Removed locally**: the sheet exists remotely but has been removed from tracking using `cogs rm` (use `cogs push` to sync)
-* **Removed remotely**: the sheet exists locally but has been removed from remote spreadsheet (use `cogs pull` to sync)
+* **Changed**: the sheet exists both locally and remotely (cached in the `.cogs` directory), but there is a difference between the local and cached version
+    * use `cogs diff [path]` to see details
+    * use `cogs push` to sync local changes to remote version (overwriting any changes to remote not yet pulled)
+    * OR use `cogs pull` to sync remote changes to local version (overwriting any changes to local not yet pushed)
+* **Added locally**: the sheet exists locally and has been added to tracking, but is not yet pushed to the remote spreadsheet
+    * use `cogs push` to add the sheet to the remote spreadsheet
+* **Added remotely**: the sheet exists remotely and has been added to tracking, but is not yet pulled to a local copy
+    * use `cogs pull` to add the sheet to locally
+* **Removed locally**: the sheet exists remotely but has been removed from tracking using `cogs rm`
+    * use `cogs push` to remove the sheet from the remote spreadsheet
+* **Removed remotely**: the sheet exists locally but has been removed from remote spreadsheet
+    * use `cogs pull` to remove the sheet locally

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 COGS takes a set of TSV files on your local file system and allows you to edit them using Google Sheets.
 
 
-## Design
+## Overview
 
 Since COGS is designed to synchronize local and remote sets of tables,
 we try to follow the familiar `git` interface and workflow:
@@ -25,7 +25,15 @@ we try to follow the familiar `git` interface and workflow:
 
 There is no step corresponding to `git commit`.
 
-## Logging
+We recommend running `cogs push` after updating a local tracked sheet to keep the remote sheets in sync.
+
+When updating a remote sheet, we recommend the following to keep the local sheets in sync:
+```
+cogs fetch
+cogs pull
+```
+
+### Logging
 
 To print info-level logging messages (error and critical level messages are always printed), run any command with the `-v`/`--verbose` flag:
 
@@ -35,14 +43,14 @@ cogs [command & opts] -v
 
 Otherwise, most commands succeed silently.
 
-## Definitions
+### Definitions
 
 - **Spreadsheet**: the remote Google Sheets spreadsheet - each COGS project corresponds to one spreadsheet
 - **Sheet**: a tab in the spreadsheet - each sheet corresponds to one local TSV or CSV table
 
 ---
 
-### Getting started development
+## Development
 
 Until we distribute COGS with Pypi, and for local development on Unix (Linux or macOS), we suggest these install instructions:
 
@@ -54,61 +62,9 @@ $ pip install -e .
 $ cogs --help
 ```
 
-### `init`
-
-Running `init` creates a `.cogs` directory containing configuration data. This also creates a new Google Sheets spreadsheet and stores the ID. Optionally, this new sheet may be shared with users.
-
-```
-cogs init -c [path-to-credentials] -t [project-title] -u [email] -r [role]
-```
-
-Options:
-- `-c`/`--credentials`: **required**, path to [Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format
-- `-t`/`--title`: **required**, title of the project which will be used as the title of the Google spreadsheet
-- `-u`/`--user`: email of the user to share the sheet with (if a `--role` is not specified, this user will be a writer)
-- `-r`/`--role`: role of the user specified by `--user`: `writer` or `reader`
-- `-U`/`--users`: path to TSV containing emails and roles for multiple users (header optional)
-
-Three files are created in the `.cogs/` directory when running `init`:
-- `config.tsv`: COGS configuration, including the spreadsheet details 
-- `field.tsv`: Field names used in sheets (contains default COGS fields)
-- `sheet.tsv`: Sheet names in spreadsheet and details (empty) - the sheets correspond to local tables
-
-All other tasks will fail if a COGS project has not been initialized in the working directory.
-
 ---
 
-### `open`
-
-Running `open` displays the URL of the spreadsheet.
-
----
-
-### `delete`
-
-Running `delete` reads the configuration data in `.cogs/config.tsv` to retrieve the spreadsheet ID. This spreadsheet is deleted in Google Sheets and the `.cogs` directory containing all project data is also removed. Any local TSV/CSV tables specified as sheets in the spreadsheet are left untouched.
-
-```
-cogs delete
-```
-
----
-
-### `share`
-
-Running `share` shares the spreadsheet with the specified user(s).
-```
-cogs share -r [reader-email] -w [writer-email]
-```
-
-There are three options:
-- `-r`/`--reader`: email of the user to give read access to
-- `-w`/`--writer`: email of the user to give write access to
-- `-o`/`--owner`: email of the user to transfer ownership to
-
-We **do not recommend** transferring ownership of the COGS project spreadsheet, as this will prevent COGS from performing any administrative actions (e.g., `cogs delete`). If you do transfer ownership and wish to delete the project, you should simply remove the `.cogs/` directory and then go online to Google Sheets and manually delete the project.
-
----
+## Commands
 
 ### `add`
 
@@ -124,48 +80,17 @@ The sheet title is created from the path (e.g., `tables/foo.tsv` will be named `
 
 This does not add the table to the spreadsheet as a sheet - use `cogs push` to push all tracked local tables to the project spreadsheet.
 
----
+### `delete`
 
-### `rm`
-
-Running `rm` will stop tracking one or multiple local TSV table. They get removed from `.cogs/sheet.tsv`, and the `.cogs/field.tsv` is updated to remove the fields that were unique to those file.
-```
-cogs rm [paths]
-```
-
-This does not delete the table(s) from the spreadsheet as sheet(s) - use `cogs push` to push all tracked local tables to the project spreadsheet.
-
----
-
-### `push`
-
-Running `push` will sync the spreadsheet with your local changes. This includes creating new sheets for any added tables (`cogs add`) and deleting sheets for any removed tables (`cogs rm`). Any changes to the local tables are also pushed to the corresponding sheets.
+Running `delete` reads the configuration data in `.cogs/config.tsv` to retrieve the spreadsheet ID. This spreadsheet is deleted in Google Sheets and the `.cogs` directory containing all project data is also removed. Any local TSV/CSV tables specified as sheets in the spreadsheet are left untouched.
 
 ```
-cogs push
+cogs delete
 ```
-
----
-
-### `fetch`
-
-Running `fetch` will sync the local `.cogs/` directory with all remote spreadsheet changes.
-
-```
-cogs fetch
-```
-
-This will download all sheets in the spreadsheet to that directory as `{sheet-title}.tsv` - this will overwrite the existing sheets in `.cogs/`, but will not overwrite the local versions specified by their path. As the sheets are downloaded, the fields are checked against existing fields in `.cogs/field.tsv` and any new fields are added with the default datatype of `cogs:text` (text string). Any sheets that have been added with `add` and then pushed to the remote sheet with `push` will be given their IDs in `.cogs/sheet.tsv`.
-
-If a new sheet has been added to the Google spreadsheet, this sheet will be downloaded and added to `.cogs/sheet.tsv`. The default path for pulling changes will be the current working directory (the same directory as `.cogs/` is in). This path can be updated with `cogs mv`.
-
-To sync the local version of sheets with the data in `.cogs/`, run `cogs pull`.
-
----
 
 ### `diff`
 
-Running `diff` will display all file changes between local and remote sheets after running `cogs fetch`.
+Running `diff` will display all file changes between local and remote sheets after running `cogs fetch` or after updating a local sheet (before pushing or pulling those changes).
 
 ```
 cogs diff
@@ -203,3 +128,78 @@ To navigate the diff:
 * `b`: go to bottom (last line)
 * `r`: go to rightmost characters (last column)
 * `l`: to to leftmost characters (first column)
+
+### `fetch`
+
+Running `fetch` will sync the local `.cogs/` directory with all remote spreadsheet changes.
+
+```
+cogs fetch
+```
+
+This will download all sheets in the spreadsheet to that directory as `{sheet-title}.tsv` - this will overwrite the existing sheets in `.cogs/`, but will not overwrite the local versions specified by their path. As the sheets are downloaded, the fields are checked against existing fields in `.cogs/field.tsv` and any new fields are added with the default datatype of `cogs:text` (text string). Any sheets that have been added with `add` and then pushed to the remote sheet with `push` will be given their IDs in `.cogs/sheet.tsv`.
+
+If a new sheet has been added to the Google spreadsheet, this sheet will be downloaded and added to `.cogs/sheet.tsv`. The default path for pulling changes will be the current working directory (the same directory as `.cogs/` is in). This path can be updated with `cogs mv`.
+
+To sync the local version of sheets with the data in `.cogs/`, run `cogs pull`.
+
+### `init`
+
+Running `init` creates a `.cogs` directory containing configuration data. This also creates a new Google Sheets spreadsheet and stores the ID. Optionally, this new sheet may be shared with users.
+
+```
+cogs init -c [path-to-credentials] -t [project-title] -u [email] -r [role]
+```
+
+Options:
+- `-c`/`--credentials`: **required**, path to [Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format
+- `-t`/`--title`: **required**, title of the project which will be used as the title of the Google spreadsheet
+- `-u`/`--user`: email of the user to share the sheet with (if a `--role` is not specified, this user will be a writer)
+- `-r`/`--role`: role of the user specified by `--user`: `writer` or `reader`
+- `-U`/`--users`: path to TSV containing emails and roles for multiple users (header optional)
+
+Three files are created in the `.cogs/` directory when running `init`:
+- `config.tsv`: COGS configuration, including the spreadsheet details 
+- `field.tsv`: Field names used in sheets (contains default COGS fields)
+- `sheet.tsv`: Sheet names in spreadsheet and details (empty) - the sheets correspond to local tables
+
+All other tasks will fail if a COGS project has not been initialized in the working directory.
+
+### `open`
+
+Running `open` displays the URL of the spreadsheet.
+
+```
+cogs open
+```
+
+### `push`
+
+Running `push` will sync the spreadsheet with your local changes. This includes creating new sheets for any added tables (`cogs add`) and deleting sheets for any removed tables (`cogs rm`). Any changes to the local tables are also pushed to the corresponding sheets.
+
+```
+cogs push
+```
+
+### `rm`
+
+Running `rm` will stop tracking one or multiple local TSV table. They get removed from `.cogs/sheet.tsv`, and the `.cogs/field.tsv` is updated to remove the fields that were unique to those file.
+```
+cogs rm [paths]
+```
+
+This does not delete the table(s) from the spreadsheet as sheet(s) - use `cogs push` to push all tracked local tables to the project spreadsheet.
+
+### `share`
+
+Running `share` shares the spreadsheet with the specified user(s).
+```
+cogs share -r [reader-email] -w [writer-email]
+```
+
+There are three options:
+- `-r`/`--reader`: email of the user to give read access to
+- `-w`/`--writer`: email of the user to give write access to
+- `-o`/`--owner`: email of the user to transfer ownership to
+
+We **do not recommend** transferring ownership of the COGS project spreadsheet, as this will prevent COGS from performing any administrative actions (e.g., `cogs delete`). If you do transfer ownership and wish to delete the project, you should simply remove the `.cogs/` directory and then go online to Google Sheets and manually delete the project.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ we try to follow the familiar `git` interface and workflow:
 - [`cogs push`](#push) pushes changes to local sheets to the project spreadsheet
 - [`cogs fetch`](#fetch) fetches the data from the spreadsheet and stores it in `.cogs/`
 - `cogs mv` updates the path to the local version of a spreadsheet
-- `cogs status` summarizes the differences between tracked files and their copies in `.cogs/`
+- [`cogs status`](#status) summarizes the differences between tracked files and their copies in `.cogs/`
 - [`cogs diff`](#diff) shows detailed differences between local files and the spreadsheet
 - `cogs pull` overwrites local files with the data from the spreadsheet, if they have changed
 - [`cogs delete`](#delete) destroys the spreadsheet and configuration data, but leaves local files alone
@@ -203,3 +203,18 @@ There are three options:
 - `-o`/`--owner`: email of the user to transfer ownership to
 
 We **do not recommend** transferring ownership of the COGS project spreadsheet, as this will prevent COGS from performing any administrative actions (e.g., `cogs delete`). If you do transfer ownership and wish to delete the project, you should simply remove the `.cogs/` directory and then go online to Google Sheets and manually delete the project.
+
+### `status`
+
+Running `status` shows the difference between local and remote copies of tracked sheets.
+
+```
+cogs status
+```
+
+There are five kinds of statuses (note that any changes to the remote spreadsheet will not be accounted for until you run `cogs fetch`)
+* **Changed**: the sheet exists both locally and remotely (cached in the `.cogs` directory), but there is a difference between the local and cached version (use `cogs diff [path]` to see details; depending on if you want the local or remote changes synced, use `cogs push` or `cogs pull`, respectively)
+* **Added locally**: the sheet exists locally and has been added to tracking, but is not yet pushed to the remote spreadsheet (use `cogs push` to sync)
+* **Added remotely**: the sheet exists remotely and has been added to tracking, but is not yet pulled to a local copy (use `cogs pull` to sync)
+* **Removed locally**: the sheet exists remotely but has been removed from tracking using `cogs rm` (use `cogs push` to sync)
+* **Removed remotely**: the sheet exists locally but has been removed from remote spreadsheet (use `cogs pull` to sync)

--- a/README.md
+++ b/README.md
@@ -183,12 +183,12 @@ cogs push
 
 ### `rm`
 
-Running `rm` will stop tracking one or multiple local TSV table. They get removed from `.cogs/sheet.tsv`, and the `.cogs/field.tsv` is updated to remove the fields that were unique to those file.
+Running `rm` will stop tracking one or more local sheets. They are removed from `.cogs/sheet.tsv`, and the `.cogs/field.tsv` is updated to remove the fields that were unique to those sheets. Additionally, this does not delete any local copies of sheets specified by their paths.
 ```
 cogs rm [paths]
 ```
 
-This does not delete the table(s) from the spreadsheet as sheet(s) - use `cogs push` to push all tracked local tables to the project spreadsheet.
+This does not delete the sheet(s) from the spreadsheet - use `cogs push` to push all local changes to the remote spreadsheet and remove cached data about the sheet.
 
 ### `share`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ google
 gspread
 pytest
 tabulate
+termcolor

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -32,6 +32,25 @@ def main():
     sp = subparsers.add_parser("version", parents=[global_parser])
     sp.set_defaults(func=version)
 
+    # ------------------------------- add -------------------------------
+    sp = subparsers.add_parser("add", parents=[global_parser])
+    sp.add_argument("path", help="Path to TSV or CSV to add to COGS project")
+    sp.add_argument("-d", "--description", help="Description of sheet to add to spreadsheet")
+    sp.set_defaults(func=add.run)
+
+    # ------------------------------- delete -------------------------------
+    sp = subparsers.add_parser("delete", parents=[global_parser])
+    sp.set_defaults(func=delete.run)
+
+    # ------------------------------- diff -------------------------------
+    sp = subparsers.add_parser("diff", parents=[global_parser])
+    sp.set_defaults(func=diff.run)
+    sp.add_argument("paths", nargs="*", help="Paths to local sheets to diff")
+
+    # ------------------------------- fetch -------------------------------
+    sp = subparsers.add_parser("fetch", parents=[global_parser])
+    sp.set_defaults(func=fetch.run)
+
     # ------------------------------- init -------------------------------
     sp = subparsers.add_parser("init", parents=[global_parser])
     sp.add_argument(
@@ -45,9 +64,18 @@ def main():
     sp.add_argument("-U", "--users", help="TSV containing user emails and their roles")
     sp.set_defaults(func=init.run)
 
-    # ------------------------------- delete -------------------------------
-    sp = subparsers.add_parser("delete", parents=[global_parser])
-    sp.set_defaults(func=delete.run)
+    # ------------------------------- open -------------------------------
+    sp = subparsers.add_parser("open", parents=[global_parser])
+    sp.set_defaults(func=open.run)
+
+    # ------------------------------- push -------------------------------
+    sp = subparsers.add_parser("push", parents=[global_parser])
+    sp.set_defaults(func=push.run)
+
+    # -------------------------------- rm --------------------------------
+    sp = subparsers.add_parser("rm", parents=[global_parser])
+    sp.add_argument("paths", help="Path to TSV or CSV to remove from COGS project", nargs='+')
+    sp.set_defaults(func=rm.run)
 
     # ------------------------------- share -------------------------------
     sp = subparsers.add_parser("share", parents=[global_parser])
@@ -55,34 +83,6 @@ def main():
     sp.add_argument("-w", "--writer", help="Email of user to grant write access to")
     sp.add_argument("-r", "--reader", help="Email of user to grant read access to")
     sp.set_defaults(func=share.run)
-
-    # ------------------------------- add -------------------------------
-    sp = subparsers.add_parser("add", parents=[global_parser])
-    sp.add_argument("path", help="Path to TSV or CSV to add to COGS project")
-    sp.add_argument("-d", "--description", help="Description of sheet to add to spreadsheet")
-    sp.set_defaults(func=add.run)
-
-    # ------------------------------- push -------------------------------
-    sp = subparsers.add_parser("push", parents=[global_parser])
-    sp.set_defaults(func=push.run)
-
-    # ------------------------------- open -------------------------------
-    sp = subparsers.add_parser("open", parents=[global_parser])
-    sp.set_defaults(func=open.run)
-
-    # -------------------------------- rm --------------------------------
-    sp = subparsers.add_parser("rm", parents=[global_parser])
-    sp.add_argument("paths", help="Path to TSV or CSV to remove from COGS project", nargs='+')
-    sp.set_defaults(func=rm.run)
-
-    # ------------------------------- fetch -------------------------------
-    sp = subparsers.add_parser("fetch", parents=[global_parser])
-    sp.set_defaults(func=fetch.run)
-
-    # ------------------------------- diff -------------------------------
-    sp = subparsers.add_parser("diff", parents=[global_parser])
-    sp.set_defaults(func=diff.run)
-    sp.add_argument("paths", nargs="*", help="Paths to local sheets to diff")
 
     args = parser.parse_args()
     args.func(args)

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -12,6 +12,7 @@ import cogs.open as open
 import cogs.push as push
 import cogs.rm as rm
 import cogs.share as share
+import cogs.status as status
 
 from argparse import ArgumentParser
 
@@ -83,6 +84,10 @@ def main():
     sp.add_argument("-w", "--writer", help="Email of user to grant write access to")
     sp.add_argument("-r", "--reader", help="Email of user to grant read access to")
     sp.set_defaults(func=share.run)
+
+    # -------------------------------- status --------------------------------
+    sp = subparsers.add_parser("status", parents=[global_parser])
+    sp.set_defaults(func=status.run)
 
     args = parser.parse_args()
     args.func(args)

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -57,15 +57,8 @@ def get_diff(local, remote):
     return data_diff
 
 
-def get_version():
-    try:
-        version = pkg_resources.require("COGS")[0].version
-    except pkg_resources.DistributionNotFound:
-        version = "developer-version"
-    return version
-
-
 def get_client(credentials):
+    """Get the gspread Client to perform Google Sheets API actions."""
     try:
         gc = gspread.service_account(credentials)
         gc.login()
@@ -87,6 +80,7 @@ def get_client(credentials):
 
 
 def get_colstr(n):
+    """Transform an int (corresponding to a column) to a letter column for use in Google Sheets"""
     string = ""
     while n > 0:
         n, remainder = divmod(n - 1, 26)
@@ -133,6 +127,15 @@ def get_sheets():
     return sheets
 
 
+def get_version():
+    """Get the version of COGS."""
+    try:
+        version = pkg_resources.require("COGS")[0].version
+    except pkg_resources.DistributionNotFound:
+        version = "developer-version"
+    return version
+
+
 def is_email(email):
     """Check if a string matches a general email pattern (user@domain.tld)"""
     return re.match(r"^[-.\w]+@[-\w]+\.[-\w]+$", email)
@@ -144,6 +147,7 @@ def is_valid_role(role):
 
 
 def set_logging(verbose):
+    """Set logging for COGS based on -v/--verbose."""
     if verbose:
         logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     else:

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -151,7 +151,7 @@ def set_logging(verbose):
     if verbose:
         logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     else:
-        logging.basicConfig(level=logging.ERROR, format="%(levelname)s: %(message)s")
+        logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 
 
 def validate_cogs_project():

--- a/src/cogs/push.py
+++ b/src/cogs/push.py
@@ -3,6 +3,8 @@ import logging
 import os
 import sys
 
+import cogs.status as status
+
 from cogs.exceptions import CogsError
 from cogs.helpers import (
     get_client,
@@ -26,23 +28,8 @@ def push(args):
     gc = get_client(config["Credentials"])
     spreadsheet = gc.open(config["Title"])
 
-    # Compare local sheets (paths) to remote sheets (in .cogs/)
-    local_sheets = get_sheets()
-    has_diff = False
-    for sheet_title, details in local_sheets.items():
-        remote_sheet = f".cogs/{sheet_title}.tsv"
-        local_sheet = details["Path"]
-        if os.path.exists(remote_sheet) and os.path.exists(local_sheet):
-            sheet_diff = get_diff(local_sheet, remote_sheet)
-            if len(sheet_diff) > 1:
-                has_diff = True
-        else:
-            has_diff = True
-
-    # Do nothing if there is no diff
-    if not has_diff:
-        print("Remote sheets are up to date with local sheets (nothing to push).\n")
-        return
+    # Get tracked sheets
+    tracked_sheets = get_sheets()
 
     # Clear existing sheets (wait to delete any that were removed)
     # If we delete first, could throw error where we try to delete the last remaining ws
@@ -55,13 +42,16 @@ def push(args):
 
     # Add new data to the sheets in the Sheet
     sheet_rows = []
-    for sheet_title, details in local_sheets.items():
+    for sheet_title, details in tracked_sheets.items():
         sheet_path = details["Path"]
         delimiter = "\t"
         if sheet_path.endswith(".csv"):
             delimiter = ","
         rows = []
         cols = 0
+        if not os.path.exists(sheet_path):
+            logging.warning(f"'{sheet_title}' exists remotely but has not been pulled")
+            continue
         with open(sheet_path, "r") as f:
             reader = csv.reader(f, delimiter=delimiter)
             for row in reader:
@@ -103,9 +93,13 @@ def push(args):
             writer.writerows(rows)
 
     for sheet_title, sheet in remote_sheets.items():
-        if sheet_title not in local_sheets.keys():
+        if sheet_title not in tracked_sheets.keys():
             logging.info(f"removing sheet '{sheet_title}'")
+            # Remove remote copy
             spreadsheet.del_worksheet(sheet)
+            # Remove local copy
+            if os.path.exists(f".cogs/{sheet_title}.tsv"):
+                os.remove(f".cogs/{sheet_title}.tsv")
 
     with open(".cogs/sheet.tsv", "w") as f:
         writer = csv.DictWriter(

--- a/src/cogs/rm.py
+++ b/src/cogs/rm.py
@@ -60,9 +60,10 @@ def rm(args):
     fields_candidates_for_removal = set()
 
     for title, sheet in sheets.items():
-        if not os.path.exists(f".cogs/{title}.tsv"):
-            continue
-        if os.stat(f".cogs/{title}.tsv").st_size == 0:
+        if (
+            not os.path.exists(f".cogs/{title}.tsv")
+            or os.stat(f".cogs/{title}.tsv").st_size == 0
+        ):
             continue
         with open(f".cogs/{title}.tsv", "r") as sheet_file:
             try:

--- a/src/cogs/rm.py
+++ b/src/cogs/rm.py
@@ -60,6 +60,10 @@ def rm(args):
     fields_candidates_for_removal = set()
 
     for title, sheet in sheets.items():
+        if not os.path.exists(f".cogs/{title}.tsv"):
+            continue
+        if os.stat(f".cogs/{title}.tsv").st_size == 0:
+            continue
         with open(f".cogs/{title}.tsv", "r") as sheet_file:
             try:
                 reader = csv.DictReader(sheet_file, delimiter="\t")
@@ -89,11 +93,6 @@ def rm(args):
             if items["Label"] not in fields_to_remove:
                 items["Field"] = field
                 writer.writerow(items)
-
-    # We finally delete the cached copies
-    for sheet_title in sheets_to_remove.keys():
-        os.remove(f".cogs/{sheet_title}.tsv")
-        logging.info(f"successfully removed '{sheet_title}'")
 
 
 def run(args):

--- a/src/cogs/status.py
+++ b/src/cogs/status.py
@@ -6,8 +6,6 @@ import termcolor
 from cogs.exceptions import CogsError
 from cogs.helpers import (
     get_diff,
-    get_client,
-    get_config,
     get_sheets,
     set_logging,
     validate_cogs_project,

--- a/src/cogs/status.py
+++ b/src/cogs/status.py
@@ -1,0 +1,223 @@
+import logging
+import os
+import sys
+import termcolor
+
+from cogs.exceptions import CogsError
+from cogs.helpers import (
+    get_diff,
+    get_client,
+    get_config,
+    get_sheets,
+    set_logging,
+    validate_cogs_project,
+)
+
+
+def get_changes(spreadsheet, tracked_sheets):
+    """Get sets of changes between local and remote sheets."""
+    # Get all remote sheet titles
+    remote_sheet_titles = []
+    for sheet in spreadsheet.worksheets():
+        remote_sheet_titles.append(sheet.title)
+
+    # Get all cached sheet titles that are not COGS defaults
+    cached_sheet_titles = []
+    for f in os.listdir(".cogs"):
+        if f not in ["user.tsv", "sheet.tsv", "field.tsv", "config.tsv"]:
+            cached_sheet_titles.append(f.split(".")[0])
+
+    # Get all tracked sheet titles
+    tracked_sheet_titles = list(tracked_sheets.keys())
+
+    # Get tracked titles that have local copies
+    local_sheet_titles = []
+
+    # And tracked titles that have been pushed to remote (given ID)
+    pushed_local_sheet_titles = []
+
+    for sheet_title, details in tracked_sheets.items():
+        local_sheet = details["Path"]
+        sid = details["ID"].strip()
+        if sid != "":
+            pushed_local_sheet_titles.append(sheet_title)
+        if os.path.exists(local_sheet):
+            local_sheet_titles.append(sheet_title)
+
+    removed_remote = []
+    added_local = []
+    removed_local = []
+    added_remote = []
+    diffs = {}
+
+    all_sheets = set(local_sheet_titles + tracked_sheet_titles + remote_sheet_titles)
+    for sheet_title in all_sheets:
+        # Does the sheet exist in the remote spreadsheet?
+        remote = False
+        if sheet_title in remote_sheet_titles:
+            remote = True
+
+        # Is the sheet cached in .cogs?
+        cached = False
+        if sheet_title in cached_sheet_titles:
+            cached = True
+
+        # Is the sheet tracked in sheet.tsv?
+        tracked = False
+        if sheet_title in tracked_sheet_titles:
+            tracked = True
+
+        # Does the sheet exist at its local path?
+        local = False
+        if sheet_title in local_sheet_titles:
+            local = True
+
+        # Does the sheet have an ID (meaning it has been pushed)?
+        local_pushed = False
+        if sheet_title in pushed_local_sheet_titles:
+            local_pushed = True
+
+        if tracked and local and local_pushed and not remote:
+            # Removed remotely and not yet pulled
+            removed_remote.append(sheet_title)
+        elif tracked and local and not local_pushed and not remote:
+            # Added locally and not yet pushed
+            added_local.append(sheet_title)
+        elif not tracked and not local and remote:
+            # Removed locally and not yet pushed
+            removed_local.append(sheet_title)
+        elif tracked and not local and remote and cached:
+            # Added remotely and not yet pulled
+            added_remote.append(sheet_title)
+        else:
+            # Exists in both - run diff
+            local_path = tracked_sheets[sheet_title]["Path"]
+            remote_path = f".cogs/{sheet_title}.tsv"
+            diff = get_diff(local_path, remote_path)
+            if len(diff) > 1:
+                added_lines = 0
+                removed_lines = 0
+                changed_lines = 0
+                added_cols = 0
+                removed_cols = 0
+                for idx in range(0, len(diff)):
+                    d = diff[idx]
+                    if idx == 0 and d[0] == "!":
+                        # Get changed columns
+                        for h in d:
+                            if h == "+++":
+                                added_cols += 1
+                            elif h == "---":
+                                removed_cols += 1
+                        continue
+                    if d[0] == "---":
+                        removed_lines += 1
+                    elif d[0] == "+++":
+                        added_lines += 1
+                    elif d[0] == "->":
+                        changed_lines += 1
+                diffs[sheet_title] = {
+                    "added_cols": added_cols,
+                    "removed_cols": removed_cols,
+                    "added_lines": added_lines,
+                    "removed_lines": removed_lines,
+                    "changed_lines": changed_lines,
+                }
+
+    return diffs, added_local, added_remote, removed_local, removed_remote
+
+
+def status(args):
+    """Print the status of local sheets vs. remote sheets."""
+    set_logging(args.verbose)
+    validate_cogs_project()
+
+    config = get_config()
+    gc = get_client(config["Credentials"])
+    title = config["Title"]
+    spreadsheet = gc.open(title)
+
+    # Get the sets of changes
+    tracked_sheets = get_sheets()
+    diffs, added_local, added_remote, removed_local, removed_remote = get_changes(
+        spreadsheet, tracked_sheets
+    )
+
+    # Check to see if we have any changes
+    all_changes = set(
+        list(diffs.keys()) + added_local + added_remote + removed_local + removed_remote
+    )
+    if len(all_changes) == 0:
+        print("Local sheets are up to date with remote spreadsheet.")
+        return
+
+    # Print various changes
+    if len(diffs) > 0:
+        print(termcolor.colored("\nChanged:", attrs=["bold"]))
+        print(
+            "  (use `cogs pull` to sync local with remote version)\n  "
+            "(use `cogs push` to sync remote with local version)"
+        )
+        for sheet_title, diff in diffs.items():
+            path = tracked_sheets[sheet_title]["Path"]
+            print(termcolor.colored(f"\t{sheet_title} ({path})", "cyan"))
+            added_lines = diff["added_lines"]
+            removed_lines = diff["removed_lines"]
+            changed_lines = diff["changed_lines"]
+            added_cols = diff["added_cols"]
+            removed_cols = diff["removed_cols"]
+            if added_cols:
+                print(termcolor.colored(f"\t  {added_cols} added column(s)", "green"))
+            if added_lines:
+                print(termcolor.colored(f"\t  {added_lines} added line(s)", "green"))
+            if removed_cols:
+                print(termcolor.colored(f"\t  {removed_cols} removed column(s)", "red"))
+            if removed_lines:
+                print(termcolor.colored(f"\t  {removed_lines} removed line(s)", "red"))
+            if changed_lines:
+                print(termcolor.colored(f"\t  {changed_lines} changed line(s)", "cyan"))
+    if len(added_local) > 0:
+        print(termcolor.colored("\nAdded locally:", attrs=["bold"]))
+        print(
+            "  (use `cogs push` to add to remote spreadsheet)\n  "
+            "(use `cogs rm [path]` to remove from tracked sheets)"
+        )
+        for sheet_title in added_local:
+            path = tracked_sheets[sheet_title]["Path"]
+            print(termcolor.colored(f"\t{sheet_title} ({path})", "green"))
+    if len(added_remote) > 0:
+        print(termcolor.colored("\nAdded remotely:", attrs=["bold"]))
+        print(
+            "  (use `cogs pull` to add to local sheets)\n  "
+            "(use `cogs rm [path]` to remove from tracked sheets)"
+        )
+        for sheet_title in added_remote:
+            path = tracked_sheets[sheet_title]["Path"]
+            print(termcolor.colored(f"\t{sheet_title} ({path})", "green"))
+    if len(removed_local) > 0:
+        print(termcolor.colored("\nRemoved locally:", attrs=["bold"]))
+        print(
+            "  (use `cogs push` to remove from remote spreadsheet)\n  "
+            "(use `cogs add [path]` to re-add to tracked sheets)"
+        )
+        for sheet_title in removed_local:
+            print(termcolor.colored(f"\t{sheet_title}", "red"))
+    if len(removed_remote) > 0:
+        print(termcolor.colored("\nRemoved remotely:", attrs=["bold"]))
+        print(
+            "  (use `cogs pull` to remove from local sheets)\n  "
+            "(use `cogs push` to re-add to remote spreadsheet)"
+        )
+        for sheet_title in removed_remote:
+            path = tracked_sheets[sheet_title]["Path"]
+            print(termcolor.colored(f"\t{sheet_title} ({path})", "red"))
+    print("")
+
+
+def run(args):
+    """Wrapper for status function."""
+    try:
+        status(args)
+    except CogsError as e:
+        logging.critical(str(e))
+        sys.exit(1)

--- a/src/cogs/status.py
+++ b/src/cogs/status.py
@@ -43,7 +43,7 @@ def get_changes(tracked_sheets):
     added_remote = []
     diffs = {}
 
-    all_sheets = set(local_sheet_titles + tracked_sheet_titles)
+    all_sheets = set(local_sheet_titles + tracked_sheet_titles + cached_sheet_titles)
     for sheet_title in all_sheets:
         # Is the sheet cached in .cogs?
         cached = False
@@ -71,7 +71,7 @@ def get_changes(tracked_sheets):
         elif tracked and local and not local_pushed and not cached:
             # Added locally and not yet pushed
             added_local.append(sheet_title)
-        elif not tracked and not local and not cached:
+        elif not tracked and not local and cached:
             # Removed locally and not yet pushed
             removed_local.append(sheet_title)
         elif tracked and not local and cached:
@@ -81,7 +81,17 @@ def get_changes(tracked_sheets):
             # Exists in both - run diff
             local_path = tracked_sheets[sheet_title]["Path"]
             remote_path = f".cogs/{sheet_title}.tsv"
-            diff = get_diff(local_path, remote_path)
+
+            # Check which version is newer based on file modification
+            local_mod = os.path.getmtime(local_path)
+            remote_mod = os.path.getmtime(remote_path)
+            if remote_mod > local_mod:
+                diff = get_diff(remote_path, local_path)
+                new_version = "remote"
+            else:
+                diff = get_diff(local_path, remote_path)
+                new_version = "local"
+
             if len(diff) > 1:
                 added_lines = 0
                 removed_lines = 0
@@ -105,6 +115,7 @@ def get_changes(tracked_sheets):
                     elif d[0] == "->":
                         changed_lines += 1
                 diffs[sheet_title] = {
+                    "new_version": new_version,
                     "added_cols": added_cols,
                     "removed_cols": removed_cols,
                     "added_lines": added_lines,
@@ -115,6 +126,70 @@ def get_changes(tracked_sheets):
     return diffs, added_local, added_remote, removed_local, removed_remote
 
 
+def print_diff(sheet_title, path, diff):
+    """Print the diff summary for a sheet."""
+    new_version = diff["new_version"]
+    added_lines = diff["added_lines"]
+    removed_lines = diff["removed_lines"]
+    changed_lines = diff["changed_lines"]
+    added_cols = diff["added_cols"]
+    removed_cols = diff["removed_cols"]
+
+    print(termcolor.colored(f"\t{sheet_title} ({path})", "cyan"))
+
+    if added_cols and added_lines:
+        col = "column"
+        if added_cols > 1:
+            col = "columns"
+        line = "line"
+        if added_lines > 1:
+            line = "lines"
+        print(
+            termcolor.colored(
+                f"\t  + {added_cols} {col}, {added_lines} {line}", "green"
+            )
+        )
+    elif added_lines:
+        line = "line"
+        if added_lines > 1:
+            line = "lines"
+        print(termcolor.colored(f"\t  + {added_lines} {line}", "green"))
+    elif added_cols:
+        col = "column"
+        if added_cols > 1:
+            col = "columns"
+        print(termcolor.colored(f"\t  + {added_cols} {col}", "green"))
+
+    if removed_cols and removed_lines:
+        col = "column"
+        if removed_cols > 1:
+            col = "columns"
+        line = "line"
+        if removed_lines > 1:
+            line = "lines"
+        print(
+            termcolor.colored(
+                f"\t  - {removed_cols} {col}, {removed_lines} {line}", "red"
+            )
+        )
+    elif removed_cols:
+        col = "column"
+        if removed_cols > 1:
+            col = "columns"
+        print(termcolor.colored(f"\t  - {removed_cols} {col}", "red"))
+    elif removed_lines:
+        line = "line"
+        if removed_lines > 1:
+            line = "lines"
+        print(termcolor.colored(f"\t  - {removed_lines} {line}", "red"))
+
+    if changed_lines:
+        line = "line"
+        if changed_lines > 1:
+            line = "lines"
+        print(termcolor.colored(f"\t  -> {changed_lines} changed {line}", "cyan"))
+
+
 def status(args):
     """Print the status of local sheets vs. remote sheets."""
     set_logging(args.verbose)
@@ -122,7 +197,9 @@ def status(args):
 
     # Get the sets of changes
     tracked_sheets = get_sheets()
-    diffs, added_local, added_remote, removed_local, removed_remote = get_changes(tracked_sheets)
+    diffs, added_local, added_remote, removed_local, removed_remote = get_changes(
+        tracked_sheets
+    )
 
     # Check to see if we have any changes
     all_changes = set(
@@ -134,61 +211,52 @@ def status(args):
 
     # Print various changes
     if len(diffs) > 0:
-        print(termcolor.colored("\nChanged:", attrs=["bold"]))
-        print(
-            "  (use `cogs pull` to sync local with remote version)\n  "
-            "(use `cogs push` to sync remote with local version)"
-        )
-        for sheet_title, diff in diffs.items():
-            path = tracked_sheets[sheet_title]["Path"]
-            print(termcolor.colored(f"\t{sheet_title} ({path})", "cyan"))
-            added_lines = diff["added_lines"]
-            removed_lines = diff["removed_lines"]
-            changed_lines = diff["changed_lines"]
-            added_cols = diff["added_cols"]
-            removed_cols = diff["removed_cols"]
-            if added_cols:
-                print(termcolor.colored(f"\t  {added_cols} added column(s)", "green"))
-            if added_lines:
-                print(termcolor.colored(f"\t  {added_lines} added line(s)", "green"))
-            if removed_cols:
-                print(termcolor.colored(f"\t  {removed_cols} removed column(s)", "red"))
-            if removed_lines:
-                print(termcolor.colored(f"\t  {removed_lines} removed line(s)", "red"))
-            if changed_lines:
-                print(termcolor.colored(f"\t  {changed_lines} changed line(s)", "cyan"))
+        changed_local = {
+            sheet_title: diff
+            for sheet_title, diff in diffs.items()
+            if diff["new_version"] == "local"
+        }
+        changed_remote = {
+            sheet_title: diff
+            for sheet_title, diff in diffs.items()
+            if diff["new_version"] == "remote"
+        }
+        if len(changed_local) > 0:
+            print(termcolor.colored("\nModified locally:", attrs=["bold"]))
+            print("  (use `cogs push` to sync remote with local version)")
+            for sheet_title, diff in changed_local.items():
+                path = tracked_sheets[sheet_title]["Path"]
+                print_diff(sheet_title, path, diff)
+        if len(changed_remote) > 0:
+            print(termcolor.colored("\nModified remotely:", attrs=["bold"]))
+            print("  (use `cogs pull` to sync local with remote version)")
+            for sheet_title, diff in changed_remote.items():
+                path = tracked_sheets[sheet_title]["Path"]
+                print_diff(sheet_title, path, diff)
+
     if len(added_local) > 0:
         print(termcolor.colored("\nAdded locally:", attrs=["bold"]))
-        print(
-            "  (use `cogs push` to add to remote spreadsheet)\n  "
-            "(use `cogs rm [path]` to remove from tracked sheets)"
-        )
+        print("  (use `cogs push` to add to remote spreadsheet)\n  ")
         for sheet_title in added_local:
             path = tracked_sheets[sheet_title]["Path"]
             print(termcolor.colored(f"\t{sheet_title} ({path})", "green"))
+
     if len(added_remote) > 0:
         print(termcolor.colored("\nAdded remotely:", attrs=["bold"]))
-        print(
-            "  (use `cogs pull` to add to local sheets)\n  "
-            "(use `cogs rm [path]` to remove from tracked sheets)"
-        )
+        print("  (use `cogs pull` to add to local sheets)")
         for sheet_title in added_remote:
             path = tracked_sheets[sheet_title]["Path"]
             print(termcolor.colored(f"\t{sheet_title} ({path})", "green"))
+
     if len(removed_local) > 0:
         print(termcolor.colored("\nRemoved locally:", attrs=["bold"]))
-        print(
-            "  (use `cogs push` to remove from remote spreadsheet)\n  "
-            "(use `cogs add [path]` to re-add to tracked sheets)"
-        )
+        print("  (use `cogs push` to remove from remote spreadsheet)")
         for sheet_title in removed_local:
             print(termcolor.colored(f"\t{sheet_title}", "red"))
+
     if len(removed_remote) > 0:
         print(termcolor.colored("\nRemoved remotely:", attrs=["bold"]))
-        print(
-            "  (use `cogs pull` to remove from local sheets)\n  "
-            "(use `cogs push` to re-add to remote spreadsheet)"
-        )
+        print("  (use `cogs pull` to remove from local sheets)")
         for sheet_title in removed_remote:
             path = tracked_sheets[sheet_title]["Path"]
             print(termcolor.colored(f"\t{sheet_title} ({path})", "red"))


### PR DESCRIPTION
Resolves #10 

Code clean up:
* Clean up the docs & `cli.py` a bit (alphabetize the commands)
* Add some comments to `helpers.py`
* Fix issue in `fetch` where if a sheet was removed remotely, it was never removed from the cache
* Fix issue in `rm` where if _any_ tracked file did not exist in `.cogs` (e.g. added but not pushed), the command failed

### `status`

Running `status` shows the difference between local and remote copies of tracked sheets.

```
cogs status
```

There are five kinds of statuses (note that any changes to the remote spreadsheet will not be accounted for until you run `cogs fetch`)
* **Modified locally**: the sheet exists both locally and remotely, but the local version has been edited since the last time `cogs fetch` or `cogs push` were run
    * use `cogs diff [path]` to see details
	* use `cogs push` to sync local changes to remote version (overwriting any changes to remote not yet pulled)
* **Modified remotely**: the sheet exists both locally and remotely, but `cogs fetch` has been run and returned a modified sheet since the last time the local version was edited
    * use `cogs diff [path]` to see details
    * use `cogs pull` to sync remote changes to local version (overwriting any changes to local not yet pushed)
* **Added locally**: the sheet exists locally and has been added to tracking, but is not yet pushed to the remote spreadsheet
    * use `cogs push` to add the sheet to the remote spreadsheet
* **Added remotely**: the sheet exists remotely and has been added to tracking, but is not yet pulled to a local copy
    * use `cogs pull` to add the sheet to locally
* **Removed locally**: the sheet exists remotely but has been removed from tracking using `cogs rm`
    * use `cogs push` to remove the sheet from the remote spreadsheet
* **Removed remotely**: the sheet exists locally but has been removed from remote spreadsheet
    * use `cogs pull` to remove the sheet locally