### PR TITLE
Add 'pull' and 'mv' commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ we try to follow the familiar `git` interface and workflow:
 - `cogs mv` updates the path to the local version of a spreadsheet
 - [`cogs status`](#status) summarizes the differences between tracked files and their copies in `.cogs/`
 - [`cogs diff`](#diff) shows detailed differences between local files and the spreadsheet
-- `cogs pull` overwrites local files with the data from the spreadsheet, if they have changed
+- [`cogs pull`](#pull) overwrites local files with the data from the spreadsheet, if they have changed
 - [`cogs delete`](#delete) destroys the spreadsheet and configuration data, but leaves local files alone
 
 There is no step corresponding to `git commit`.
@@ -172,6 +172,16 @@ Running `open` displays the URL of the spreadsheet.
 ```
 cogs open
 ```
+
+### `pull`
+
+Running `pull` will sync local sheets with remote sheets after running `cogs fetch`.
+
+```
+cogs pull
+```
+
+Note that if you make changes to a local sheet without running `cogs push`, then run `cogs fetch` and `cogs pull`, the local changes **will be overwritten**.
 
 ### `push`
 

--- a/README.md
+++ b/README.md
@@ -213,10 +213,12 @@ cogs status
 ```
 
 There are five kinds of statuses (note that any changes to the remote spreadsheet will not be accounted for until you run `cogs fetch`)
-* **Changed**: the sheet exists both locally and remotely (cached in the `.cogs` directory), but there is a difference between the local and cached version
+* **Modified locally**: the sheet exists both locally and remotely, but the local version has been edited since the last time `cogs fetch` or `cogs push` were run
     * use `cogs diff [path]` to see details
-    * use `cogs push` to sync local changes to remote version (overwriting any changes to remote not yet pulled)
-    * OR use `cogs pull` to sync remote changes to local version (overwriting any changes to local not yet pushed)
+	* use `cogs push` to sync local changes to remote version (overwriting any changes to remote not yet pulled)
+* **Modified remotely**: the sheet exists both locally and remotely, but `cogs fetch` has been run and returned a modified sheet since the last time the local version was edited
+    * use `cogs diff [path]` to see details
+    * use `cogs pull` to sync remote changes to local version (overwriting any changes to local not yet pushed)
 * **Added locally**: the sheet exists locally and has been added to tracking, but is not yet pushed to the remote spreadsheet
     * use `cogs push` to add the sheet to the remote spreadsheet
 * **Added remotely**: the sheet exists remotely and has been added to tracking, but is not yet pulled to a local copy

--- a/README.md
+++ b/README.md
@@ -213,8 +213,15 @@ cogs status
 ```
 
 There are five kinds of statuses (note that any changes to the remote spreadsheet will not be accounted for until you run `cogs fetch`)
-* **Changed**: the sheet exists both locally and remotely (cached in the `.cogs` directory), but there is a difference between the local and cached version (use `cogs diff [path]` to see details; depending on if you want the local or remote changes synced, use `cogs push` or `cogs pull`, respectively)
-* **Added locally**: the sheet exists locally and has been added to tracking, but is not yet pushed to the remote spreadsheet (use `cogs push` to sync)
-* **Added remotely**: the sheet exists remotely and has been added to tracking, but is not yet pulled to a local copy (use `cogs pull` to sync)
-* **Removed locally**: the sheet exists remotely but has been removed from tracking using `cogs rm` (use `cogs push` to sync)
-* **Removed remotely**: the sheet exists locally but has been removed from remote spreadsheet (use `cogs pull` to sync)
+* **Changed**: the sheet exists both locally and remotely (cached in the `.cogs` directory), but there is a difference between the local and cached version
+    * use `cogs diff [path]` to see details
+    * use `cogs push` to sync local changes to remote version (overwriting any changes to remote not yet pulled)
+    * OR use `cogs pull` to sync remote changes to local version (overwriting any changes to local not yet pushed)
+* **Added locally**: the sheet exists locally and has been added to tracking, but is not yet pushed to the remote spreadsheet
+    * use `cogs push` to add the sheet to the remote spreadsheet
+* **Added remotely**: the sheet exists remotely and has been added to tracking, but is not yet pulled to a local copy
+    * use `cogs pull` to add the sheet to locally
+* **Removed locally**: the sheet exists remotely but has been removed from tracking using `cogs rm`
+    * use `cogs push` to remove the sheet from the remote spreadsheet
+* **Removed remotely**: the sheet exists locally but has been removed from remote spreadsheet
+    * use `cogs pull` to remove the sheet locally

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 COGS takes a set of TSV files on your local file system and allows you to edit them using Google Sheets.
 
 
-## Design
+## Overview
 
 Since COGS is designed to synchronize local and remote sets of tables,
 we try to follow the familiar `git` interface and workflow:
@@ -25,7 +25,15 @@ we try to follow the familiar `git` interface and workflow:
 
 There is no step corresponding to `git commit`.
 
-## Logging
+We recommend running `cogs push` after updating a local tracked sheet to keep the remote sheets in sync.
+
+When updating a remote sheet, we recommend the following to keep the local sheets in sync:
+```
+cogs fetch
+cogs pull
+```
+
+### Logging
 
 To print info-level logging messages (error and critical level messages are always printed), run any command with the `-v`/`--verbose` flag:
 
@@ -35,14 +43,14 @@ cogs [command & opts] -v
 
 Otherwise, most commands succeed silently.
 
-## Definitions
+### Definitions
 
 - **Spreadsheet**: the remote Google Sheets spreadsheet - each COGS project corresponds to one spreadsheet
 - **Sheet**: a tab in the spreadsheet - each sheet corresponds to one local TSV or CSV table
 
 ---
 
-### Getting started development
+## Development
 
 Until we distribute COGS with Pypi, and for local development on Unix (Linux or macOS), we suggest these install instructions:
 
@@ -54,61 +62,9 @@ $ pip install -e .
 $ cogs --help
 ```
 
-### `init`
-
-Running `init` creates a `.cogs` directory containing configuration data. This also creates a new Google Sheets spreadsheet and stores the ID. Optionally, this new sheet may be shared with users.
-
-```
-cogs init -c [path-to-credentials] -t [project-title] -u [email] -r [role]
-```
-
-Options:
-- `-c`/`--credentials`: **required**, path to [Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format
-- `-t`/`--title`: **required**, title of the project which will be used as the title of the Google spreadsheet
-- `-u`/`--user`: email of the user to share the sheet with (if a `--role` is not specified, this user will be a writer)
-- `-r`/`--role`: role of the user specified by `--user`: `writer` or `reader`
-- `-U`/`--users`: path to TSV containing emails and roles for multiple users (header optional)
-
-Three files are created in the `.cogs/` directory when running `init`:
-- `config.tsv`: COGS configuration, including the spreadsheet details 
-- `field.tsv`: Field names used in sheets (contains default COGS fields)
-- `sheet.tsv`: Sheet names in spreadsheet and details (empty) - the sheets correspond to local tables
-
-All other tasks will fail if a COGS project has not been initialized in the working directory.
-
 ---
 
-### `open`
-
-Running `open` displays the URL of the spreadsheet.
-
----
-
-### `delete`
-
-Running `delete` reads the configuration data in `.cogs/config.tsv` to retrieve the spreadsheet ID. This spreadsheet is deleted in Google Sheets and the `.cogs` directory containing all project data is also removed. Any local TSV/CSV tables specified as sheets in the spreadsheet are left untouched.
-
-```
-cogs delete
-```
-
----
-
-### `share`
-
-Running `share` shares the spreadsheet with the specified user(s).
-```
-cogs share -r [reader-email] -w [writer-email]
-```
-
-There are three options:
-- `-r`/`--reader`: email of the user to give read access to
-- `-w`/`--writer`: email of the user to give write access to
-- `-o`/`--owner`: email of the user to transfer ownership to
-
-We **do not recommend** transferring ownership of the COGS project spreadsheet, as this will prevent COGS from performing any administrative actions (e.g., `cogs delete`). If you do transfer ownership and wish to delete the project, you should simply remove the `.cogs/` directory and then go online to Google Sheets and manually delete the project.
-
----
+## Commands
 
 ### `add`
 
@@ -124,48 +80,17 @@ The sheet title is created from the path (e.g., `tables/foo.tsv` will be named `
 
 This does not add the table to the spreadsheet as a sheet - use `cogs push` to push all tracked local tables to the project spreadsheet.
 
----
+### `delete`
 
-### `rm`
-
-Running `rm` will stop tracking one or multiple local TSV table. They get removed from `.cogs/sheet.tsv`, and the `.cogs/field.tsv` is updated to remove the fields that were unique to those file.
-```
-cogs rm [paths]
-```
-
-This does not delete the table(s) from the spreadsheet as sheet(s) - use `cogs push` to push all tracked local tables to the project spreadsheet.
-
----
-
-### `push`
-
-Running `push` will sync the spreadsheet with your local changes. This includes creating new sheets for any added tables (`cogs add`) and deleting sheets for any removed tables (`cogs rm`). Any changes to the local tables are also pushed to the corresponding sheets.
+Running `delete` reads the configuration data in `.cogs/config.tsv` to retrieve the spreadsheet ID. This spreadsheet is deleted in Google Sheets and the `.cogs` directory containing all project data is also removed. Any local TSV/CSV tables specified as sheets in the spreadsheet are left untouched.
 
 ```
-cogs push
+cogs delete
 ```
-
----
-
-### `fetch`
-
-Running `fetch` will sync the local `.cogs/` directory with all remote spreadsheet changes.
-
-```
-cogs fetch
-```
-
-This will download all sheets in the spreadsheet to that directory as `{sheet-title}.tsv` - this will overwrite the existing sheets in `.cogs/`, but will not overwrite the local versions specified by their path. As the sheets are downloaded, the fields are checked against existing fields in `.cogs/field.tsv` and any new fields are added with the default datatype of `cogs:text` (text string). Any sheets that have been added with `add` and then pushed to the remote sheet with `push` will be given their IDs in `.cogs/sheet.tsv`.
-
-If a new sheet has been added to the Google spreadsheet, this sheet will be downloaded and added to `.cogs/sheet.tsv`. The default path for pulling changes will be the current working directory (the same directory as `.cogs/` is in). This path can be updated with `cogs mv`.
-
-To sync the local version of sheets with the data in `.cogs/`, run `cogs pull`.
-
----
 
 ### `diff`
 
-Running `diff` will display all file changes between local and remote sheets after running `cogs fetch`.
+Running `diff` will display all file changes between local and remote sheets after running `cogs fetch` or after updating a local sheet (before pushing or pulling those changes).
 
 ```
 cogs diff
@@ -203,3 +128,78 @@ To navigate the diff:
 * `b`: go to bottom (last line)
 * `r`: go to rightmost characters (last column)
 * `l`: to to leftmost characters (first column)
+
+### `fetch`
+
+Running `fetch` will sync the local `.cogs/` directory with all remote spreadsheet changes.
+
+```
+cogs fetch
+```
+
+This will download all sheets in the spreadsheet to that directory as `{sheet-title}.tsv` - this will overwrite the existing sheets in `.cogs/`, but will not overwrite the local versions specified by their path. As the sheets are downloaded, the fields are checked against existing fields in `.cogs/field.tsv` and any new fields are added with the default datatype of `cogs:text` (text string). Any sheets that have been added with `add` and then pushed to the remote sheet with `push` will be given their IDs in `.cogs/sheet.tsv`.
+
+If a new sheet has been added to the Google spreadsheet, this sheet will be downloaded and added to `.cogs/sheet.tsv`. The default path for pulling changes will be the current working directory (the same directory as `.cogs/` is in). This path can be updated with `cogs mv`.
+
+To sync the local version of sheets with the data in `.cogs/`, run `cogs pull`.
+
+### `init`
+
+Running `init` creates a `.cogs` directory containing configuration data. This also creates a new Google Sheets spreadsheet and stores the ID. Optionally, this new sheet may be shared with users.
+
+```
+cogs init -c [path-to-credentials] -t [project-title] -u [email] -r [role]
+```
+
+Options:
+- `-c`/`--credentials`: **required**, path to [Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format
+- `-t`/`--title`: **required**, title of the project which will be used as the title of the Google spreadsheet
+- `-u`/`--user`: email of the user to share the sheet with (if a `--role` is not specified, this user will be a writer)
+- `-r`/`--role`: role of the user specified by `--user`: `writer` or `reader`
+- `-U`/`--users`: path to TSV containing emails and roles for multiple users (header optional)
+
+Three files are created in the `.cogs/` directory when running `init`:
+- `config.tsv`: COGS configuration, including the spreadsheet details 
+- `field.tsv`: Field names used in sheets (contains default COGS fields)
+- `sheet.tsv`: Sheet names in spreadsheet and details (empty) - the sheets correspond to local tables
+
+All other tasks will fail if a COGS project has not been initialized in the working directory.
+
+### `open`
+
+Running `open` displays the URL of the spreadsheet.
+
+```
+cogs open
+```
+
+### `push`
+
+Running `push` will sync the spreadsheet with your local changes. This includes creating new sheets for any added tables (`cogs add`) and deleting sheets for any removed tables (`cogs rm`). Any changes to the local tables are also pushed to the corresponding sheets.
+
+```
+cogs push
+```
+
+### `rm`
+
+Running `rm` will stop tracking one or multiple local TSV table. They get removed from `.cogs/sheet.tsv`, and the `.cogs/field.tsv` is updated to remove the fields that were unique to those file.
+```
+cogs rm [paths]
+```
+
+This does not delete the table(s) from the spreadsheet as sheet(s) - use `cogs push` to push all tracked local tables to the project spreadsheet.
+
+### `share`
+
+Running `share` shares the spreadsheet with the specified user(s).
+```
+cogs share -r [reader-email] -w [writer-email]
+```
+
+There are three options:
+- `-r`/`--reader`: email of the user to give read access to
+- `-w`/`--writer`: email of the user to give write access to
+- `-o`/`--owner`: email of the user to transfer ownership to
+
+We **do not recommend** transferring ownership of the COGS project spreadsheet, as this will prevent COGS from performing any administrative actions (e.g., `cogs delete`). If you do transfer ownership and wish to delete the project, you should simply remove the `.cogs/` directory and then go online to Google Sheets and manually delete the project.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Otherwise, most commands succeed silently.
 
 - **Spreadsheet**: the remote Google Sheets spreadsheet - each COGS project corresponds to one spreadsheet
 - **Sheet**: a tab in the spreadsheet - each sheet corresponds to one local TSV or CSV table
+- **Remote**: data from Google Sheets
+- **Local**: data from your local working directory
+- **Cached**: data stored in `.cogs/` which is fetched from the remote spreadsheet
 
 ---
 
@@ -223,7 +226,7 @@ cogs status
 ```
 
 There are five kinds of statuses (note that any changes to the remote spreadsheet will not be accounted for until you run `cogs fetch`)
-* **Modified locally**: the sheet exists both locally and remotely, but the local version has been edited since the last time `cogs fetch` or `cogs push` were run
+* **Modified locally**: the sheet exists both locally and remotely (cached), but the local version has been edited since the last time `cogs fetch` or `cogs push` were run
     * use `cogs diff [path]` to see details
 	* use `cogs push` to sync local changes to remote version (overwriting any changes to remote not yet pulled)
 * **Modified remotely**: the sheet exists both locally and remotely, but `cogs fetch` has been run and returned a modified sheet since the last time the local version was edited

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ we try to follow the familiar `git` interface and workflow:
 - [`cogs rm foo.tsv`](#rm) stops tracking the `foo.tsv` table as a sheet
 - [`cogs push`](#push) pushes changes to local sheets to the project spreadsheet
 - [`cogs fetch`](#fetch) fetches the data from the spreadsheet and stores it in `.cogs/`
-- `cogs mv` updates the path to the local version of a spreadsheet
+- [`cogs mv foo.tsv bar.tsv`](#mv) updates the path to the local version of a spreadsheet from `foo.tsv` to `bar.tsv`
 - [`cogs status`](#status) summarizes the differences between tracked files and their copies in `.cogs/`
 - [`cogs diff`](#diff) shows detailed differences between local files and the spreadsheet
 - [`cogs pull`](#pull) overwrites local files with the data from the spreadsheet, if they have changed
@@ -79,7 +79,7 @@ cogs add [path] -d "[description]"
 
 The `-d`/`--description` is optional.
 
-The sheet title is created from the path (e.g., `tables/foo.tsv` will be named `foo`). If a sheet with this title already exists in the project, the task will fail. The sheet/file name cannot be one of the COGS reserved names: `config`, `field`, `sheet`, or `user`.
+The sheet title is created from the path (e.g., `tables/foo.tsv` will be named `foo`). If a sheet with this title already exists in the project, the task will fail. The sheet/file name cannot be one of the COGS reserved names: `config`, `field`, `sheet`, `renamed`, or `user`.
 
 This does not add the table to the spreadsheet as a sheet - use `cogs push` to push all tracked local tables to the project spreadsheet.
 
@@ -146,6 +146,8 @@ If a new sheet has been added to the Google spreadsheet, this sheet will be down
 
 To sync the local version of sheets with the data in `.cogs/`, run `cogs pull`.
 
+Note that if a sheet has been _renamed_ remotely, the old sheet title will be replaced with the new sheet title. Any changes made to the local file corresponding to the old title will not be synced with the remote spreadsheet. Instead, once you run `cogs pull`, a new sheet `{new-sheet-title}.tsv` will appear in the current working directory (the same as if a new sheet were created). It is the same as if you were to delete the old sheet remotely and create a new sheet remotely with the same contents. Use `cogs pull` to write the new path - the old local file will not be deleted.
+
 ### `init`
 
 Running `init` creates a `.cogs` directory containing configuration data. This also creates a new Google Sheets spreadsheet and stores the ID. Optionally, this new sheet may be shared with users.
@@ -193,6 +195,18 @@ Running `push` will sync the spreadsheet with your local changes. This includes 
 ```
 cogs push
 ```
+
+### `mv`
+
+Running `mv` will update the path of a local sheet.
+
+```
+cogs mv [old_path] [new_path]
+```
+
+The old path must exist as a local file. It will be renamed to the new path during this process. If the basename of the new path (e.g., `tables/foo.tsv` -> `foo`) is already a tracked sheet, this command will fail as you cannot have two sheets with the same name.
+
+We recommend running `cogs push` after `cogs mv` to keep the remote spreadsheet in sync.
 
 ### `rm`
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ we try to follow the familiar `git` interface and workflow:
 - [`cogs push`](#push) pushes changes to local sheets to the project spreadsheet
 - [`cogs fetch`](#fetch) fetches the data from the spreadsheet and stores it in `.cogs/`
 - `cogs mv` updates the path to the local version of a spreadsheet
-- `cogs status` summarizes the differences between tracked files and their copies in `.cogs/`
+- [`cogs status`](#status) summarizes the differences between tracked files and their copies in `.cogs/`
 - [`cogs diff`](#diff) shows detailed differences between local files and the spreadsheet
 - `cogs pull` overwrites local files with the data from the spreadsheet, if they have changed
 - [`cogs delete`](#delete) destroys the spreadsheet and configuration data, but leaves local files alone
@@ -203,3 +203,18 @@ There are three options:
 - `-o`/`--owner`: email of the user to transfer ownership to
 
 We **do not recommend** transferring ownership of the COGS project spreadsheet, as this will prevent COGS from performing any administrative actions (e.g., `cogs delete`). If you do transfer ownership and wish to delete the project, you should simply remove the `.cogs/` directory and then go online to Google Sheets and manually delete the project.
+
+### `status`
+
+Running `status` shows the difference between local and remote copies of tracked sheets.
+
+```
+cogs status
+```
+
+There are five kinds of statuses (note that any changes to the remote spreadsheet will not be accounted for until you run `cogs fetch`)
+* **Changed**: the sheet exists both locally and remotely (cached in the `.cogs` directory), but there is a difference between the local and cached version (use `cogs diff [path]` to see details; depending on if you want the local or remote changes synced, use `cogs push` or `cogs pull`, respectively)
+* **Added locally**: the sheet exists locally and has been added to tracking, but is not yet pushed to the remote spreadsheet (use `cogs push` to sync)
+* **Added remotely**: the sheet exists remotely and has been added to tracking, but is not yet pulled to a local copy (use `cogs pull` to sync)
+* **Removed locally**: the sheet exists remotely but has been removed from tracking using `cogs rm` (use `cogs push` to sync)
+* **Removed remotely**: the sheet exists locally but has been removed from remote spreadsheet (use `cogs pull` to sync)

--- a/README.md
+++ b/README.md
@@ -183,12 +183,12 @@ cogs push
 
 ### `rm`
 
-Running `rm` will stop tracking one or multiple local TSV table. They get removed from `.cogs/sheet.tsv`, and the `.cogs/field.tsv` is updated to remove the fields that were unique to those file.
+Running `rm` will stop tracking one or more local sheets. They are removed from `.cogs/sheet.tsv`, and the `.cogs/field.tsv` is updated to remove the fields that were unique to those sheets. Additionally, this does not delete any local copies of sheets specified by their paths.
 ```
 cogs rm [paths]
 ```
 
-This does not delete the table(s) from the spreadsheet as sheet(s) - use `cogs push` to push all tracked local tables to the project spreadsheet.
+This does not delete the sheet(s) from the spreadsheet - use `cogs push` to push all local changes to the remote spreadsheet and remove cached data about the sheet.
 
 ### `share`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ google
 gspread
 pytest
 tabulate
+termcolor

--- a/src/cogs/add.py
+++ b/src/cogs/add.py
@@ -29,7 +29,7 @@ def add(args):
 
     # Create the sheet title from file basename
     title = ntpath.basename(args.path).split(".")[0]
-    if title in ["user", "config", "sheet", "field"]:
+    if title in ["user", "config", "sheet", "field", "renamed"]:
         raise AddError(f"sheet cannot use reserved name '{title}'")
 
     # Make sure we aren't duplicating a table

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -9,6 +9,7 @@ import cogs.fetch as fetch
 import cogs.helpers as helpers
 import cogs.init as init
 import cogs.open as open
+import cogs.pull as pull
 import cogs.push as push
 import cogs.rm as rm
 import cogs.share as share
@@ -68,6 +69,10 @@ def main():
     # ------------------------------- open -------------------------------
     sp = subparsers.add_parser("open", parents=[global_parser])
     sp.set_defaults(func=open.run)
+
+    # ------------------------------- pull -------------------------------
+    sp = subparsers.add_parser("pull", parents=[global_parser])
+    sp.set_defaults(func=pull.run)
 
     # ------------------------------- push -------------------------------
     sp = subparsers.add_parser("push", parents=[global_parser])

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -32,6 +32,25 @@ def main():
     sp = subparsers.add_parser("version", parents=[global_parser])
     sp.set_defaults(func=version)
 
+    # ------------------------------- add -------------------------------
+    sp = subparsers.add_parser("add", parents=[global_parser])
+    sp.add_argument("path", help="Path to TSV or CSV to add to COGS project")
+    sp.add_argument("-d", "--description", help="Description of sheet to add to spreadsheet")
+    sp.set_defaults(func=add.run)
+
+    # ------------------------------- delete -------------------------------
+    sp = subparsers.add_parser("delete", parents=[global_parser])
+    sp.set_defaults(func=delete.run)
+
+    # ------------------------------- diff -------------------------------
+    sp = subparsers.add_parser("diff", parents=[global_parser])
+    sp.set_defaults(func=diff.run)
+    sp.add_argument("paths", nargs="*", help="Paths to local sheets to diff")
+
+    # ------------------------------- fetch -------------------------------
+    sp = subparsers.add_parser("fetch", parents=[global_parser])
+    sp.set_defaults(func=fetch.run)
+
     # ------------------------------- init -------------------------------
     sp = subparsers.add_parser("init", parents=[global_parser])
     sp.add_argument(
@@ -45,9 +64,18 @@ def main():
     sp.add_argument("-U", "--users", help="TSV containing user emails and their roles")
     sp.set_defaults(func=init.run)
 
-    # ------------------------------- delete -------------------------------
-    sp = subparsers.add_parser("delete", parents=[global_parser])
-    sp.set_defaults(func=delete.run)
+    # ------------------------------- open -------------------------------
+    sp = subparsers.add_parser("open", parents=[global_parser])
+    sp.set_defaults(func=open.run)
+
+    # ------------------------------- push -------------------------------
+    sp = subparsers.add_parser("push", parents=[global_parser])
+    sp.set_defaults(func=push.run)
+
+    # -------------------------------- rm --------------------------------
+    sp = subparsers.add_parser("rm", parents=[global_parser])
+    sp.add_argument("paths", help="Path to TSV or CSV to remove from COGS project", nargs='+')
+    sp.set_defaults(func=rm.run)
 
     # ------------------------------- share -------------------------------
     sp = subparsers.add_parser("share", parents=[global_parser])
@@ -55,34 +83,6 @@ def main():
     sp.add_argument("-w", "--writer", help="Email of user to grant write access to")
     sp.add_argument("-r", "--reader", help="Email of user to grant read access to")
     sp.set_defaults(func=share.run)
-
-    # ------------------------------- add -------------------------------
-    sp = subparsers.add_parser("add", parents=[global_parser])
-    sp.add_argument("path", help="Path to TSV or CSV to add to COGS project")
-    sp.add_argument("-d", "--description", help="Description of sheet to add to spreadsheet")
-    sp.set_defaults(func=add.run)
-
-    # ------------------------------- push -------------------------------
-    sp = subparsers.add_parser("push", parents=[global_parser])
-    sp.set_defaults(func=push.run)
-
-    # ------------------------------- open -------------------------------
-    sp = subparsers.add_parser("open", parents=[global_parser])
-    sp.set_defaults(func=open.run)
-
-    # -------------------------------- rm --------------------------------
-    sp = subparsers.add_parser("rm", parents=[global_parser])
-    sp.add_argument("paths", help="Path to TSV or CSV to remove from COGS project", nargs='+')
-    sp.set_defaults(func=rm.run)
-
-    # ------------------------------- fetch -------------------------------
-    sp = subparsers.add_parser("fetch", parents=[global_parser])
-    sp.set_defaults(func=fetch.run)
-
-    # ------------------------------- diff -------------------------------
-    sp = subparsers.add_parser("diff", parents=[global_parser])
-    sp.set_defaults(func=diff.run)
-    sp.add_argument("paths", nargs="*", help="Paths to local sheets to diff")
 
     args = parser.parse_args()
     args.func(args)

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -12,6 +12,7 @@ import cogs.open as open
 import cogs.push as push
 import cogs.rm as rm
 import cogs.share as share
+import cogs.status as status
 
 from argparse import ArgumentParser
 
@@ -83,6 +84,10 @@ def main():
     sp.add_argument("-w", "--writer", help="Email of user to grant write access to")
     sp.add_argument("-r", "--reader", help="Email of user to grant read access to")
     sp.set_defaults(func=share.run)
+
+    # -------------------------------- status --------------------------------
+    sp = subparsers.add_parser("status", parents=[global_parser])
+    sp.set_defaults(func=status.run)
 
     args = parser.parse_args()
     args.func(args)

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -8,6 +8,7 @@ import cogs.diff as diff
 import cogs.fetch as fetch
 import cogs.helpers as helpers
 import cogs.init as init
+import cogs.mv as mv
 import cogs.open as open
 import cogs.pull as pull
 import cogs.push as push
@@ -65,6 +66,12 @@ def main():
     )
     sp.add_argument("-U", "--users", help="TSV containing user emails and their roles")
     sp.set_defaults(func=init.run)
+
+    # ------------------------------- mv -------------------------------
+    sp = subparsers.add_parser("mv", parents=[global_parser])
+    sp.add_argument("path", help="Path of local sheet to move")
+    sp.add_argument("new_path", help="New path for local sheet")
+    sp.set_defaults(func=mv.run)
 
     # ------------------------------- open -------------------------------
     sp = subparsers.add_parser("open", parents=[global_parser])

--- a/src/cogs/delete.py
+++ b/src/cogs/delete.py
@@ -20,7 +20,7 @@ def delete(args):
         "         Do you wish to proceed? [y/n]\n"
     )
     if resp.lower().strip() != "y":
-        logging.info("'delete' operation stopped")
+        logging.warning("'delete' operation stopped")
         sys.exit(0)
 
     # Get a client to perform Sheet actions

--- a/src/cogs/exceptions.py
+++ b/src/cogs/exceptions.py
@@ -22,5 +22,9 @@ class InitError(CogsError):
     """Used to indicate an error occurred during the init step."""
 
 
+class MvError(CogsError):
+    """Used to indicate an error occurred during the mv step."""
+
+
 class RmError(CogsError):
     """Used to indicate an error occurred during the rm step."""

--- a/src/cogs/fetch.py
+++ b/src/cogs/fetch.py
@@ -49,9 +49,9 @@ def fetch(args):
         int(details["ID"]): sheet_title for sheet_title, details in tracked_sheets.items()
     }
 
+    # Get details about renamed sheets
     renamed_local = get_renamed()
     new_local_titles = [details["new"] for details in renamed_local.values()]
-
     renamed_remote = {}
 
     # Export the sheets as TSV to .cogs/ (while checking the fieldnames)

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -57,15 +57,8 @@ def get_diff(local, remote):
     return data_diff
 
 
-def get_version():
-    try:
-        version = pkg_resources.require("COGS")[0].version
-    except pkg_resources.DistributionNotFound:
-        version = "developer-version"
-    return version
-
-
 def get_client(credentials):
+    """Get the gspread Client to perform Google Sheets API actions."""
     try:
         gc = gspread.service_account(credentials)
         gc.login()
@@ -87,6 +80,7 @@ def get_client(credentials):
 
 
 def get_colstr(n):
+    """Transform an int (corresponding to a column) to a letter column for use in Google Sheets"""
     string = ""
     while n > 0:
         n, remainder = divmod(n - 1, 26)
@@ -133,6 +127,15 @@ def get_sheets():
     return sheets
 
 
+def get_version():
+    """Get the version of COGS."""
+    try:
+        version = pkg_resources.require("COGS")[0].version
+    except pkg_resources.DistributionNotFound:
+        version = "developer-version"
+    return version
+
+
 def is_email(email):
     """Check if a string matches a general email pattern (user@domain.tld)"""
     return re.match(r"^[-.\w]+@[-\w]+\.[-\w]+$", email)
@@ -144,6 +147,7 @@ def is_valid_role(role):
 
 
 def set_logging(verbose):
+    """Set logging for COGS based on -v/--verbose."""
     if verbose:
         logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     else:

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -151,7 +151,7 @@ def set_logging(verbose):
     if verbose:
         logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     else:
-        logging.basicConfig(level=logging.ERROR, format="%(levelname)s: %(message)s")
+        logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 
 
 def validate_cogs_project():

--- a/src/cogs/mv.py
+++ b/src/cogs/mv.py
@@ -1,0 +1,93 @@
+import csv
+import logging
+import ntpath
+import os
+import shutil
+import sys
+
+from cogs.exceptions import CogsError, MvError
+from cogs.helpers import get_sheets, set_logging, validate_cogs_project
+
+
+def mv(args):
+    """Move a local sheet to a new local path. If the file basename changes, the sheet title will
+    also change."""
+    set_logging(args.verbose)
+    validate_cogs_project()
+
+    if not os.path.exists(args.path):
+        raise MvError(f"{args.path} does not exist")
+
+    if os.path.exists(args.path) and os.path.exists(args.new_path):
+        # Make sure the user knows they are overwriting another file
+        i = input(
+            f"{args.path} and {args.new_path} both exist - "
+            f"'mv' will overwrite the contents of {args.new_path}.\nDo you wish to proceed? [y/n]\n"
+        )
+        if i.strip().lower() != "y":
+            logging.warning("'mv' operation stopped")
+            sys.exit(0)
+
+    # Get the tracked sheets
+    tracked_sheets = get_sheets()
+    path_to_sheet = {
+        os.path.abspath(details["Path"]): sheet_title
+        for sheet_title, details in tracked_sheets.items()
+    }
+
+    # Make sure the sheet we are moving is tracked and get its (current) title
+    cur_path = os.path.abspath(args.path)
+    if cur_path not in path_to_sheet:
+        raise MvError(f"{args.path} is not a tracked sheet")
+
+    # Move the local copy if it exists
+    # If it doesn't exist, the user has already moved to the new path
+    if os.path.exists(args.path):
+        os.rename(args.path, args.new_path)
+
+    # See if the basename (sheet title) changed
+    # If so, we need to rename the cached copy
+    selected_sheet = path_to_sheet[cur_path]
+    new_sheet_title = ntpath.basename(args.new_path).split(".")[0]
+    if selected_sheet != new_sheet_title:
+        if os.path.exists(f".cogs/{new_sheet_title}.tsv"):
+            # A cached sheet with this name already exists
+            existing_path = tracked_sheets[new_sheet_title]["Path"]
+            raise MvError(
+                f"Unable to rename '{selected_sheet}' to '{new_sheet_title}' - "
+                f"a tracked sheet with this title already exists ({existing_path})"
+            )
+        logging.info(f"Renaming '{selected_sheet}' to '{new_sheet_title}'")
+        shutil.copyfile(f".cogs/{selected_sheet}.tsv", f".cogs/{new_sheet_title}.tsv")
+        with open(".cogs/renamed.tsv", "a") as f:
+            f.write(f"{selected_sheet}\t{new_sheet_title}\t{args.new_path}\n")
+
+    # Get new rows of sheet.tsv to write
+    rows = []
+    for sheet_title, details in tracked_sheets.items():
+        if sheet_title == selected_sheet:
+            # Update path and title
+            details["Path"] = args.new_path
+            sheet_title = new_sheet_title
+        details["Title"] = sheet_title
+        rows.append(details)
+
+    # Rewrite sheet.tsv
+    with open(".cogs/sheet.tsv", "w") as f:
+        writer = csv.DictWriter(
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["ID", "Title", "Path", "Description"],
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def run(args):
+    """Wrapper for mv function."""
+    try:
+        mv(args)
+    except CogsError as e:
+        logging.critical(str(e))
+        sys.exit(1)

--- a/src/cogs/pull.py
+++ b/src/cogs/pull.py
@@ -1,0 +1,30 @@
+import logging
+import os
+import shutil
+import sys
+
+from cogs.exceptions import CogsError
+from cogs.helpers import get_sheets, set_logging, validate_cogs_project
+
+
+def pull(args):
+    """Copy cached sheets to their local paths."""
+    set_logging(args.verbose)
+    validate_cogs_project()
+
+    tracked_sheets = get_sheets()
+    for sheet_title, details in tracked_sheets.items():
+        cached_sheet = f".cogs/{sheet_title}.tsv"
+        local_sheet = details["Path"]
+        if os.path.exists(cached_sheet):
+            logging.info(f"Writing '{sheet_title}' to {local_sheet}")
+            shutil.copyfile(cached_sheet, local_sheet)
+
+
+def run(args):
+    """Wrapper for pull function."""
+    try:
+        pull(args)
+    except CogsError as e:
+        logging.critical(str(e))
+        sys.exit(1)

--- a/src/cogs/pull.py
+++ b/src/cogs/pull.py
@@ -4,7 +4,7 @@ import shutil
 import sys
 
 from cogs.exceptions import CogsError
-from cogs.helpers import get_sheets, set_logging, validate_cogs_project
+from cogs.helpers import get_cached, get_sheets, set_logging, validate_cogs_project
 
 
 def pull(args):
@@ -12,13 +12,18 @@ def pull(args):
     set_logging(args.verbose)
     validate_cogs_project()
 
+    cached_sheets = get_cached()
     tracked_sheets = get_sheets()
+    remove_sheets = [s for s in cached_sheets if s not in tracked_sheets.keys()]
     for sheet_title, details in tracked_sheets.items():
         cached_sheet = f".cogs/{sheet_title}.tsv"
         local_sheet = details["Path"]
         if os.path.exists(cached_sheet):
             logging.info(f"Writing '{sheet_title}' to {local_sheet}")
             shutil.copyfile(cached_sheet, local_sheet)
+    for sheet_title in remove_sheets:
+        logging.info(f"Removing '{sheet_title}' from cached sheets")
+        os.remove(f".cogs/{sheet_title}.tsv")
 
 
 def run(args):

--- a/src/cogs/push.py
+++ b/src/cogs/push.py
@@ -3,6 +3,8 @@ import logging
 import os
 import sys
 
+import cogs.status as status
+
 from cogs.exceptions import CogsError
 from cogs.helpers import (
     get_client,
@@ -26,23 +28,8 @@ def push(args):
     gc = get_client(config["Credentials"])
     spreadsheet = gc.open(config["Title"])
 
-    # Compare local sheets (paths) to remote sheets (in .cogs/)
-    local_sheets = get_sheets()
-    has_diff = False
-    for sheet_title, details in local_sheets.items():
-        remote_sheet = f".cogs/{sheet_title}.tsv"
-        local_sheet = details["Path"]
-        if os.path.exists(remote_sheet) and os.path.exists(local_sheet):
-            sheet_diff = get_diff(local_sheet, remote_sheet)
-            if len(sheet_diff) > 1:
-                has_diff = True
-        else:
-            has_diff = True
-
-    # Do nothing if there is no diff
-    if not has_diff:
-        print("Remote sheets are up to date with local sheets (nothing to push).\n")
-        return
+    # Get tracked sheets
+    tracked_sheets = get_sheets()
 
     # Clear existing sheets (wait to delete any that were removed)
     # If we delete first, could throw error where we try to delete the last remaining ws
@@ -55,13 +42,16 @@ def push(args):
 
     # Add new data to the sheets in the Sheet
     sheet_rows = []
-    for sheet_title, details in local_sheets.items():
+    for sheet_title, details in tracked_sheets.items():
         sheet_path = details["Path"]
         delimiter = "\t"
         if sheet_path.endswith(".csv"):
             delimiter = ","
         rows = []
         cols = 0
+        if not os.path.exists(sheet_path):
+            logging.warning(f"'{sheet_title}' exists remotely but has not been pulled")
+            continue
         with open(sheet_path, "r") as f:
             reader = csv.reader(f, delimiter=delimiter)
             for row in reader:
@@ -103,9 +93,13 @@ def push(args):
             writer.writerows(rows)
 
     for sheet_title, sheet in remote_sheets.items():
-        if sheet_title not in local_sheets.keys():
+        if sheet_title not in tracked_sheets.keys():
             logging.info(f"removing sheet '{sheet_title}'")
+            # Remove remote copy
             spreadsheet.del_worksheet(sheet)
+            # Remove local copy
+            if os.path.exists(f".cogs/{sheet_title}.tsv"):
+                os.remove(f".cogs/{sheet_title}.tsv")
 
     with open(".cogs/sheet.tsv", "w") as f:
         writer = csv.DictWriter(

--- a/src/cogs/rm.py
+++ b/src/cogs/rm.py
@@ -60,9 +60,10 @@ def rm(args):
     fields_candidates_for_removal = set()
 
     for title, sheet in sheets.items():
-        if not os.path.exists(f".cogs/{title}.tsv"):
-            continue
-        if os.stat(f".cogs/{title}.tsv").st_size == 0:
+        if (
+            not os.path.exists(f".cogs/{title}.tsv")
+            or os.stat(f".cogs/{title}.tsv").st_size == 0
+        ):
             continue
         with open(f".cogs/{title}.tsv", "r") as sheet_file:
             try:

--- a/src/cogs/rm.py
+++ b/src/cogs/rm.py
@@ -60,6 +60,10 @@ def rm(args):
     fields_candidates_for_removal = set()
 
     for title, sheet in sheets.items():
+        if not os.path.exists(f".cogs/{title}.tsv"):
+            continue
+        if os.stat(f".cogs/{title}.tsv").st_size == 0:
+            continue
         with open(f".cogs/{title}.tsv", "r") as sheet_file:
             try:
                 reader = csv.DictReader(sheet_file, delimiter="\t")
@@ -89,11 +93,6 @@ def rm(args):
             if items["Label"] not in fields_to_remove:
                 items["Field"] = field
                 writer.writerow(items)
-
-    # We finally delete the cached copies
-    for sheet_title in sheets_to_remove.keys():
-        os.remove(f".cogs/{sheet_title}.tsv")
-        logging.info(f"successfully removed '{sheet_title}'")
 
 
 def run(args):

--- a/src/cogs/status.py
+++ b/src/cogs/status.py
@@ -6,8 +6,6 @@ import termcolor
 from cogs.exceptions import CogsError
 from cogs.helpers import (
     get_diff,
-    get_client,
-    get_config,
     get_sheets,
     set_logging,
     validate_cogs_project,

--- a/src/cogs/status.py
+++ b/src/cogs/status.py
@@ -1,0 +1,223 @@
+import logging
+import os
+import sys
+import termcolor
+
+from cogs.exceptions import CogsError
+from cogs.helpers import (
+    get_diff,
+    get_client,
+    get_config,
+    get_sheets,
+    set_logging,
+    validate_cogs_project,
+)
+
+
+def get_changes(spreadsheet, tracked_sheets):
+    """Get sets of changes between local and remote sheets."""
+    # Get all remote sheet titles
+    remote_sheet_titles = []
+    for sheet in spreadsheet.worksheets():
+        remote_sheet_titles.append(sheet.title)
+
+    # Get all cached sheet titles that are not COGS defaults
+    cached_sheet_titles = []
+    for f in os.listdir(".cogs"):
+        if f not in ["user.tsv", "sheet.tsv", "field.tsv", "config.tsv"]:
+            cached_sheet_titles.append(f.split(".")[0])
+
+    # Get all tracked sheet titles
+    tracked_sheet_titles = list(tracked_sheets.keys())
+
+    # Get tracked titles that have local copies
+    local_sheet_titles = []
+
+    # And tracked titles that have been pushed to remote (given ID)
+    pushed_local_sheet_titles = []
+
+    for sheet_title, details in tracked_sheets.items():
+        local_sheet = details["Path"]
+        sid = details["ID"].strip()
+        if sid != "":
+            pushed_local_sheet_titles.append(sheet_title)
+        if os.path.exists(local_sheet):
+            local_sheet_titles.append(sheet_title)
+
+    removed_remote = []
+    added_local = []
+    removed_local = []
+    added_remote = []
+    diffs = {}
+
+    all_sheets = set(local_sheet_titles + tracked_sheet_titles + remote_sheet_titles)
+    for sheet_title in all_sheets:
+        # Does the sheet exist in the remote spreadsheet?
+        remote = False
+        if sheet_title in remote_sheet_titles:
+            remote = True
+
+        # Is the sheet cached in .cogs?
+        cached = False
+        if sheet_title in cached_sheet_titles:
+            cached = True
+
+        # Is the sheet tracked in sheet.tsv?
+        tracked = False
+        if sheet_title in tracked_sheet_titles:
+            tracked = True
+
+        # Does the sheet exist at its local path?
+        local = False
+        if sheet_title in local_sheet_titles:
+            local = True
+
+        # Does the sheet have an ID (meaning it has been pushed)?
+        local_pushed = False
+        if sheet_title in pushed_local_sheet_titles:
+            local_pushed = True
+
+        if tracked and local and local_pushed and not remote:
+            # Removed remotely and not yet pulled
+            removed_remote.append(sheet_title)
+        elif tracked and local and not local_pushed and not remote:
+            # Added locally and not yet pushed
+            added_local.append(sheet_title)
+        elif not tracked and not local and remote:
+            # Removed locally and not yet pushed
+            removed_local.append(sheet_title)
+        elif tracked and not local and remote and cached:
+            # Added remotely and not yet pulled
+            added_remote.append(sheet_title)
+        else:
+            # Exists in both - run diff
+            local_path = tracked_sheets[sheet_title]["Path"]
+            remote_path = f".cogs/{sheet_title}.tsv"
+            diff = get_diff(local_path, remote_path)
+            if len(diff) > 1:
+                added_lines = 0
+                removed_lines = 0
+                changed_lines = 0
+                added_cols = 0
+                removed_cols = 0
+                for idx in range(0, len(diff)):
+                    d = diff[idx]
+                    if idx == 0 and d[0] == "!":
+                        # Get changed columns
+                        for h in d:
+                            if h == "+++":
+                                added_cols += 1
+                            elif h == "---":
+                                removed_cols += 1
+                        continue
+                    if d[0] == "---":
+                        removed_lines += 1
+                    elif d[0] == "+++":
+                        added_lines += 1
+                    elif d[0] == "->":
+                        changed_lines += 1
+                diffs[sheet_title] = {
+                    "added_cols": added_cols,
+                    "removed_cols": removed_cols,
+                    "added_lines": added_lines,
+                    "removed_lines": removed_lines,
+                    "changed_lines": changed_lines,
+                }
+
+    return diffs, added_local, added_remote, removed_local, removed_remote
+
+
+def status(args):
+    """Print the status of local sheets vs. remote sheets."""
+    set_logging(args.verbose)
+    validate_cogs_project()
+
+    config = get_config()
+    gc = get_client(config["Credentials"])
+    title = config["Title"]
+    spreadsheet = gc.open(title)
+
+    # Get the sets of changes
+    tracked_sheets = get_sheets()
+    diffs, added_local, added_remote, removed_local, removed_remote = get_changes(
+        spreadsheet, tracked_sheets
+    )
+
+    # Check to see if we have any changes
+    all_changes = set(
+        list(diffs.keys()) + added_local + added_remote + removed_local + removed_remote
+    )
+    if len(all_changes) == 0:
+        print("Local sheets are up to date with remote spreadsheet.")
+        return
+
+    # Print various changes
+    if len(diffs) > 0:
+        print(termcolor.colored("\nChanged:", attrs=["bold"]))
+        print(
+            "  (use `cogs pull` to sync local with remote version)\n  "
+            "(use `cogs push` to sync remote with local version)"
+        )
+        for sheet_title, diff in diffs.items():
+            path = tracked_sheets[sheet_title]["Path"]
+            print(termcolor.colored(f"\t{sheet_title} ({path})", "cyan"))
+            added_lines = diff["added_lines"]
+            removed_lines = diff["removed_lines"]
+            changed_lines = diff["changed_lines"]
+            added_cols = diff["added_cols"]
+            removed_cols = diff["removed_cols"]
+            if added_cols:
+                print(termcolor.colored(f"\t  {added_cols} added column(s)", "green"))
+            if added_lines:
+                print(termcolor.colored(f"\t  {added_lines} added line(s)", "green"))
+            if removed_cols:
+                print(termcolor.colored(f"\t  {removed_cols} removed column(s)", "red"))
+            if removed_lines:
+                print(termcolor.colored(f"\t  {removed_lines} removed line(s)", "red"))
+            if changed_lines:
+                print(termcolor.colored(f"\t  {changed_lines} changed line(s)", "cyan"))
+    if len(added_local) > 0:
+        print(termcolor.colored("\nAdded locally:", attrs=["bold"]))
+        print(
+            "  (use `cogs push` to add to remote spreadsheet)\n  "
+            "(use `cogs rm [path]` to remove from tracked sheets)"
+        )
+        for sheet_title in added_local:
+            path = tracked_sheets[sheet_title]["Path"]
+            print(termcolor.colored(f"\t{sheet_title} ({path})", "green"))
+    if len(added_remote) > 0:
+        print(termcolor.colored("\nAdded remotely:", attrs=["bold"]))
+        print(
+            "  (use `cogs pull` to add to local sheets)\n  "
+            "(use `cogs rm [path]` to remove from tracked sheets)"
+        )
+        for sheet_title in added_remote:
+            path = tracked_sheets[sheet_title]["Path"]
+            print(termcolor.colored(f"\t{sheet_title} ({path})", "green"))
+    if len(removed_local) > 0:
+        print(termcolor.colored("\nRemoved locally:", attrs=["bold"]))
+        print(
+            "  (use `cogs push` to remove from remote spreadsheet)\n  "
+            "(use `cogs add [path]` to re-add to tracked sheets)"
+        )
+        for sheet_title in removed_local:
+            print(termcolor.colored(f"\t{sheet_title}", "red"))
+    if len(removed_remote) > 0:
+        print(termcolor.colored("\nRemoved remotely:", attrs=["bold"]))
+        print(
+            "  (use `cogs pull` to remove from local sheets)\n  "
+            "(use `cogs push` to re-add to remote spreadsheet)"
+        )
+        for sheet_title in removed_remote:
+            path = tracked_sheets[sheet_title]["Path"]
+            print(termcolor.colored(f"\t{sheet_title} ({path})", "red"))
+    print("")
+
+
+def run(args):
+    """Wrapper for status function."""
+    try:
+        status(args)
+    except CogsError as e:
+        logging.critical(str(e))
+        sys.exit(1)

--- a/src/cogs/status.py
+++ b/src/cogs/status.py
@@ -70,15 +70,16 @@ def get_changes(tracked_sheets, renamed):
         elif tracked and local and not local_pushed and not cached:
             # Added locally and not yet pushed
             added_local.append(sheet_title)
-        elif not tracked and not local and cached:
-            if sheet_title not in renamed:
-                # Removed locally and not yet pushed
-                removed_local.append(sheet_title)
+        elif not tracked and not local and cached and sheet_title not in renamed:
+            # Removed locally and not yet pushed
+            removed_local.append(sheet_title)
         elif tracked and not local and cached:
             # Added remotely and not yet pulled
             added_remote.append(sheet_title)
         else:
             # Exists in both - run diff
+            if sheet_title in renamed:
+                sheet_title = renamed[sheet_title]["new"]
             local_path = tracked_sheets[sheet_title]["Path"]
             remote_path = f".cogs/{sheet_title}.tsv"
 

--- a/src/cogs/status.py
+++ b/src/cogs/status.py
@@ -43,7 +43,7 @@ def get_changes(tracked_sheets):
     added_remote = []
     diffs = {}
 
-    all_sheets = set(local_sheet_titles + tracked_sheet_titles)
+    all_sheets = set(local_sheet_titles + tracked_sheet_titles + cached_sheet_titles)
     for sheet_title in all_sheets:
         # Is the sheet cached in .cogs?
         cached = False
@@ -71,7 +71,7 @@ def get_changes(tracked_sheets):
         elif tracked and local and not local_pushed and not cached:
             # Added locally and not yet pushed
             added_local.append(sheet_title)
-        elif not tracked and not local and not cached:
+        elif not tracked and not local and cached:
             # Removed locally and not yet pushed
             removed_local.append(sheet_title)
         elif tracked and not local and cached:
@@ -81,7 +81,17 @@ def get_changes(tracked_sheets):
             # Exists in both - run diff
             local_path = tracked_sheets[sheet_title]["Path"]
             remote_path = f".cogs/{sheet_title}.tsv"
-            diff = get_diff(local_path, remote_path)
+
+            # Check which version is newer based on file modification
+            local_mod = os.path.getmtime(local_path)
+            remote_mod = os.path.getmtime(remote_path)
+            if remote_mod > local_mod:
+                diff = get_diff(remote_path, local_path)
+                new_version = "remote"
+            else:
+                diff = get_diff(local_path, remote_path)
+                new_version = "local"
+
             if len(diff) > 1:
                 added_lines = 0
                 removed_lines = 0
@@ -105,6 +115,7 @@ def get_changes(tracked_sheets):
                     elif d[0] == "->":
                         changed_lines += 1
                 diffs[sheet_title] = {
+                    "new_version": new_version,
                     "added_cols": added_cols,
                     "removed_cols": removed_cols,
                     "added_lines": added_lines,
@@ -115,6 +126,70 @@ def get_changes(tracked_sheets):
     return diffs, added_local, added_remote, removed_local, removed_remote
 
 
+def print_diff(sheet_title, path, diff):
+    """Print the diff summary for a sheet."""
+    new_version = diff["new_version"]
+    added_lines = diff["added_lines"]
+    removed_lines = diff["removed_lines"]
+    changed_lines = diff["changed_lines"]
+    added_cols = diff["added_cols"]
+    removed_cols = diff["removed_cols"]
+
+    print(termcolor.colored(f"\t{sheet_title} ({path})", "cyan"))
+
+    if added_cols and added_lines:
+        col = "column"
+        if added_cols > 1:
+            col = "columns"
+        line = "line"
+        if added_lines > 1:
+            line = "lines"
+        print(
+            termcolor.colored(
+                f"\t  + {added_cols} {col}, {added_lines} {line}", "green"
+            )
+        )
+    elif added_lines:
+        line = "line"
+        if added_lines > 1:
+            line = "lines"
+        print(termcolor.colored(f"\t  + {added_lines} {line}", "green"))
+    elif added_cols:
+        col = "column"
+        if added_cols > 1:
+            col = "columns"
+        print(termcolor.colored(f"\t  + {added_cols} {col}", "green"))
+
+    if removed_cols and removed_lines:
+        col = "column"
+        if removed_cols > 1:
+            col = "columns"
+        line = "line"
+        if removed_lines > 1:
+            line = "lines"
+        print(
+            termcolor.colored(
+                f"\t  - {removed_cols} {col}, {removed_lines} {line}", "red"
+            )
+        )
+    elif removed_cols:
+        col = "column"
+        if removed_cols > 1:
+            col = "columns"
+        print(termcolor.colored(f"\t  - {removed_cols} {col}", "red"))
+    elif removed_lines:
+        line = "line"
+        if removed_lines > 1:
+            line = "lines"
+        print(termcolor.colored(f"\t  - {removed_lines} {line}", "red"))
+
+    if changed_lines:
+        line = "line"
+        if changed_lines > 1:
+            line = "lines"
+        print(termcolor.colored(f"\t  -> {changed_lines} changed {line}", "cyan"))
+
+
 def status(args):
     """Print the status of local sheets vs. remote sheets."""
     set_logging(args.verbose)
@@ -122,7 +197,9 @@ def status(args):
 
     # Get the sets of changes
     tracked_sheets = get_sheets()
-    diffs, added_local, added_remote, removed_local, removed_remote = get_changes(tracked_sheets)
+    diffs, added_local, added_remote, removed_local, removed_remote = get_changes(
+        tracked_sheets
+    )
 
     # Check to see if we have any changes
     all_changes = set(
@@ -134,61 +211,52 @@ def status(args):
 
     # Print various changes
     if len(diffs) > 0:
-        print(termcolor.colored("\nChanged:", attrs=["bold"]))
-        print(
-            "  (use `cogs pull` to sync local with remote version)\n  "
-            "(use `cogs push` to sync remote with local version)"
-        )
-        for sheet_title, diff in diffs.items():
-            path = tracked_sheets[sheet_title]["Path"]
-            print(termcolor.colored(f"\t{sheet_title} ({path})", "cyan"))
-            added_lines = diff["added_lines"]
-            removed_lines = diff["removed_lines"]
-            changed_lines = diff["changed_lines"]
-            added_cols = diff["added_cols"]
-            removed_cols = diff["removed_cols"]
-            if added_cols:
-                print(termcolor.colored(f"\t  {added_cols} added column(s)", "green"))
-            if added_lines:
-                print(termcolor.colored(f"\t  {added_lines} added line(s)", "green"))
-            if removed_cols:
-                print(termcolor.colored(f"\t  {removed_cols} removed column(s)", "red"))
-            if removed_lines:
-                print(termcolor.colored(f"\t  {removed_lines} removed line(s)", "red"))
-            if changed_lines:
-                print(termcolor.colored(f"\t  {changed_lines} changed line(s)", "cyan"))
+        changed_local = {
+            sheet_title: diff
+            for sheet_title, diff in diffs.items()
+            if diff["new_version"] == "local"
+        }
+        changed_remote = {
+            sheet_title: diff
+            for sheet_title, diff in diffs.items()
+            if diff["new_version"] == "remote"
+        }
+        if len(changed_local) > 0:
+            print(termcolor.colored("\nModified locally:", attrs=["bold"]))
+            print("  (use `cogs push` to sync remote with local version)")
+            for sheet_title, diff in changed_local.items():
+                path = tracked_sheets[sheet_title]["Path"]
+                print_diff(sheet_title, path, diff)
+        if len(changed_remote) > 0:
+            print(termcolor.colored("\nModified remotely:", attrs=["bold"]))
+            print("  (use `cogs pull` to sync local with remote version)")
+            for sheet_title, diff in changed_remote.items():
+                path = tracked_sheets[sheet_title]["Path"]
+                print_diff(sheet_title, path, diff)
+
     if len(added_local) > 0:
         print(termcolor.colored("\nAdded locally:", attrs=["bold"]))
-        print(
-            "  (use `cogs push` to add to remote spreadsheet)\n  "
-            "(use `cogs rm [path]` to remove from tracked sheets)"
-        )
+        print("  (use `cogs push` to add to remote spreadsheet)\n  ")
         for sheet_title in added_local:
             path = tracked_sheets[sheet_title]["Path"]
             print(termcolor.colored(f"\t{sheet_title} ({path})", "green"))
+
     if len(added_remote) > 0:
         print(termcolor.colored("\nAdded remotely:", attrs=["bold"]))
-        print(
-            "  (use `cogs pull` to add to local sheets)\n  "
-            "(use `cogs rm [path]` to remove from tracked sheets)"
-        )
+        print("  (use `cogs pull` to add to local sheets)")
         for sheet_title in added_remote:
             path = tracked_sheets[sheet_title]["Path"]
             print(termcolor.colored(f"\t{sheet_title} ({path})", "green"))
+
     if len(removed_local) > 0:
         print(termcolor.colored("\nRemoved locally:", attrs=["bold"]))
-        print(
-            "  (use `cogs push` to remove from remote spreadsheet)\n  "
-            "(use `cogs add [path]` to re-add to tracked sheets)"
-        )
+        print("  (use `cogs push` to remove from remote spreadsheet)")
         for sheet_title in removed_local:
             print(termcolor.colored(f"\t{sheet_title}", "red"))
+
     if len(removed_remote) > 0:
         print(termcolor.colored("\nRemoved remotely:", attrs=["bold"]))
-        print(
-            "  (use `cogs pull` to remove from local sheets)\n  "
-            "(use `cogs push` to re-add to remote spreadsheet)"
-        )
+        print("  (use `cogs pull` to remove from local sheets)")
         for sheet_title in removed_remote:
             path = tracked_sheets[sheet_title]["Path"]
             print(termcolor.colored(f"\t{sheet_title} ({path})", "red"))


### PR DESCRIPTION
Resolves #30 
Resolves #11 
Wait on #35

Along with the `mv` command, this updates handling for renamed sheets when running `fetch` and `push`.

This adds a new file to `.cogs` called `renamed.tsv` to track renamed sheets when running `status` and `fetch`. `renamed.tsv` will be deleted every time you run `push` to sync the renamed sheets with the remote spreadsheet. 

---

### `pull`

Running `pull` will sync local sheets with remote sheets after running `cogs fetch`.

```
cogs pull
```

Note that if you make changes to a local sheet without running `cogs push`, then run `cogs fetch` and `cogs pull`, the local changes **will be overwritten**.

### `mv`

Running `mv` will update the path of a local sheet.

```
cogs mv [old_path] [new_path]
```

The old path must exist as a local file. It will be renamed to the new path during this process. If the basename of the new path (e.g., `tables/foo.tsv` -> `foo`) is already a tracked sheet, this command will fail as you cannot have two sheets with the same name.

We recommend running `cogs push` after `cogs mv` to keep the remote spreadsheet in sync.
