### PR TITLE
Add support for tracking formats and notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ Options:
 Three files are created in the `.cogs/` directory when running `init`:
 - `config.tsv`: COGS configuration, including the spreadsheet details 
 - `field.tsv`: Field names used in sheets (contains default COGS fields)
-- `format.tsv`: Sheet ID, Cell location, and format IDs (the format for each format ID is stored as a JSON dictionary in `.cogs/formats.json`)
-- `note.tsv`: Sheet ID, Cell location, and note for all notes
+- `format.tsv`: Sheet ID, cell location or range, and format IDs (the format for each format ID is stored as a JSON dictionary in `.cogs/formats.json`)
+- `note.tsv`: Sheet ID, cell location, and note for all notes
 - `sheet.tsv`: Sheet names in spreadsheet and details (empty) - the sheets correspond to local tables
 
 All other tasks will fail if a COGS project has not been initialized in the working directory.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Otherwise, most commands succeed silently.
 - **Remote**: data from Google Sheets
 - **Local**: data from your local working directory
 - **Cached**: data stored in `.cogs/` which is fetched from the remote spreadsheet
+- **Format**: the format applied to a cell in a sheet (e.g., background color, font family, etc.)
+- **Note**: a note (a.k.a. comment) on a cell that appears when hovered over in the sheet
 
 ---
 
@@ -142,6 +144,8 @@ cogs fetch
 
 This will download all sheets in the spreadsheet to that directory as `{sheet-title}.tsv` - this will overwrite the existing sheets in `.cogs/`, but will not overwrite the local versions specified by their path. As the sheets are downloaded, the fields are checked against existing fields in `.cogs/field.tsv` and any new fields are added with the default datatype of `cogs:text` (text string). Any sheets that have been added with `add` and then pushed to the remote sheet with `push` will be given their IDs in `.cogs/sheet.tsv`.
 
+`.cogs/format.tsv` and `.cogs/note.tsv` are also updated for any cell formatting or notes on cells, respectively. Each unique format is given a numerical ID and is stored as [CellFormat JSON](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/cells#cellformat).
+
 If a new sheet has been added to the Google spreadsheet, this sheet will be downloaded and added to `.cogs/sheet.tsv`. The default path for pulling changes will be the current working directory (the same directory as `.cogs/` is in). This path can be updated with `cogs mv`.
 
 To sync the local version of sheets with the data in `.cogs/`, run `cogs pull`.
@@ -166,6 +170,8 @@ Options:
 Three files are created in the `.cogs/` directory when running `init`:
 - `config.tsv`: COGS configuration, including the spreadsheet details 
 - `field.tsv`: Field names used in sheets (contains default COGS fields)
+- `format.tsv`: Sheet ID, Cell location, and format IDs (the format for each format ID is stored as a JSON dictionary in `.cogs/formats.json`)
+- `note.tsv`: Sheet ID, Cell location, and note for all notes
 - `sheet.tsv`: Sheet names in spreadsheet and details (empty) - the sheets correspond to local tables
 
 All other tasks will fail if a COGS project has not been initialized in the working directory.
@@ -195,6 +201,8 @@ Running `push` will sync the spreadsheet with your local changes. This includes 
 ```
 cogs push
 ```
+
+This will also push all notes and formatting from `.cogs/format.tsv` and `.cogs/note.tsv`.
 
 ### `mv`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ daff
 flake8
 google
 gspread
+gspread-formatting
 pytest
 tabulate
 termcolor

--- a/src/cogs/add.py
+++ b/src/cogs/add.py
@@ -1,11 +1,8 @@
-import csv
-import logging
 import ntpath
-import re
 import sys
 
-from cogs.exceptions import CogsError, AddError
-from cogs.helpers import get_fields, get_sheets, set_logging, validate_cogs_project
+from cogs.exceptions import AddError
+from cogs.helpers import *
 
 
 def add(args):
@@ -29,7 +26,7 @@ def add(args):
 
     # Create the sheet title from file basename
     title = ntpath.basename(args.path).split(".")[0]
-    if title in ["user", "config", "sheet", "field", "renamed"]:
+    if title in reserved_names:
         raise AddError(f"sheet cannot use reserved name '{title}'")
 
     # Make sure we aren't duplicating a table

--- a/src/cogs/fetch.py
+++ b/src/cogs/fetch.py
@@ -1,18 +1,42 @@
-import csv
-import logging
-import os
+import gspread.utils
 import sys
 
-from cogs.exceptions import CogsError, FetchError
-from cogs.helpers import (
-    get_config,
-    get_client,
-    get_renamed,
-    get_sheets,
-    maybe_update_fields,
-    set_logging,
-    validate_cogs_project,
-)
+from cogs.exceptions import FetchError
+from cogs.helpers import *
+
+
+def get_cell_data(sheet):
+    """Get cell data from a remote sheet. Cell data includes formatting and notes.
+    Return as a map of cell location (e.g., B2) to {"format": dict, "note": str}."""
+    # Label is the range of cells in a sheet (e.g., foo!A1:B2)
+    last_loc = gspread.utils.rowcol_to_a1(sheet.row_count, sheet.col_count)
+    label = f"{sheet.title}!A1:{last_loc}"
+    resp = sheet.spreadsheet.fetch_sheet_metadata(
+        {
+            "includeGridData": True,
+            "ranges": label
+        }
+    )
+    cells = {}
+    idx_y = 1
+    for row in resp["sheets"][0]["data"][0]["rowData"]:
+        if not row:
+            # Empty row
+            continue
+        idx_x = 1
+        for cell in row["values"]:
+            label = gspread.utils.rowcol_to_a1(idx_y, idx_x)
+            cell_data = {}
+            if "userEnteredFormat" in cell:
+                cell_data["format"] = cell["userEnteredFormat"]
+            else:
+                cell_data["format"] = {}
+            if "note" in cell:
+                cell_data["note"] = cell["note"].replace("\n", "\\n")
+            cells[label] = cell_data
+            idx_x += 1
+        idx_y += 1
+    return cells
 
 
 def get_remote_sheets(sheets):
@@ -46,7 +70,8 @@ def fetch(args):
     remote_sheets = get_remote_sheets(sheets)
     tracked_sheets = get_sheets()
     id_to_title = {
-        int(details["ID"]): sheet_title for sheet_title, details in tracked_sheets.items()
+        int(details["ID"]): sheet_title
+        for sheet_title, details in tracked_sheets.items()
     }
 
     # Get details about renamed sheets
@@ -54,19 +79,36 @@ def fetch(args):
     new_local_titles = [details["new"] for details in renamed_local.values()]
     renamed_remote = {}
 
+    # Format ID to format for cell formatting
+    id_to_format = get_format_dict()
+    if id_to_format:
+        # Format to format ID
+        format_to_id = {json.dumps(v, sort_keys=True): k for k, v in id_to_format.items()}
+        # Next ID for new formats
+        format_ids = list(id_to_format.keys())
+        format_ids.sort()
+        next_fmt_id = int(format_ids[-1]) + 1
+    else:
+        format_to_id = {}
+        next_fmt_id = 1
+
     # Export the sheets as TSV to .cogs/ (while checking the fieldnames)
+    # We also collect the formatting and note data for each sheet during this step
+    sheet_formats = {}
+    sheet_notes = {}
     for sheet in sheets:
+        remote_title = sheet.title
         # Download the sheet as the renamed sheet if necessary
-        if sheet.title in renamed_local:
-            st = renamed_local[sheet.title]["new"]
+        if remote_title in renamed_local:
+            st = renamed_local[remote_title]["new"]
             logging.info(
-                f"Downloading remote sheet '{sheet.title}' as {st} (renamed locally)"
+                f"Downloading remote sheet '{remote_title}' as {st} (renamed locally)"
             )
         else:
-            st = sheet.title
+            st = remote_title
             if sheet.id in id_to_title:
                 local_title = id_to_title[sheet.id]
-                if local_title != sheet.title:
+                if local_title != remote_title:
                     # The sheet title has been changed remotely
                     # This will be updated in tracking but the local sheet will remain
                     old_path = tracked_sheets[local_title]["Path"]
@@ -78,6 +120,81 @@ def fetch(args):
                     )
                     renamed_remote[local_title] = {"new": st, "path": st + ".tsv"}
             logging.info(f"Downloading remote sheet '{st}'")
+
+        if st in reserved_names:
+            # Remote sheet has reserved sheet name - exit
+            raise FetchError(f"sheet cannot use reserved name '{st}'")
+
+        # Get the cells with format, value, and note from remote sheet
+        cells = get_cell_data(sheet)
+
+        # Get the ending row & col that have values
+        # Otherwise we end up with a bunch of empty rows/columns
+        max_row = 0
+        max_col = 0
+        for c in cells.keys():
+            row, col = gspread.utils.a1_to_rowcol(c)
+            if row > max_row:
+                max_row = row
+            if col > max_col:
+                max_col = col
+
+        # Cell label to format dict
+        cell_to_format = {cell: data["format"] for cell, data in cells.items() if "format" in data}
+
+        # Create a cell to format ID dict based on the format dict for each cell
+        cell_to_format_id = {}
+        last_fmt = None
+        cell_range_start = None
+        cell_range_end = None
+        for cell, fmt in cell_to_format.items():
+            if not fmt:
+                if last_fmt:
+                    if not cell_range_end or cell_range_start == cell_range_end:
+                        cell_to_format_id[cell_range_start] = last_fmt
+                    else:
+                        cell_to_format_id[f"{cell_range_start}:{cell_range_end}"] = last_fmt
+                last_fmt = None
+                cell_range_start = None
+                cell_range_end = None
+                continue
+
+            key = json.dumps(fmt, sort_keys=True)
+
+            if key in format_to_id:
+                # Format already exists, assign that ID
+                fmt_id = format_to_id[key]
+            else:
+                # Assign new ID
+                fmt_id = next_fmt_id
+                format_to_id[key] = fmt_id
+                id_to_format[fmt_id] = fmt
+                next_fmt_id += 1
+
+            if last_fmt and fmt_id == last_fmt:
+                # Add to range
+                cell_range_end = cell
+            elif last_fmt and cell_range_start and cell_range_end:
+                if cell_range_start == cell_range_end:
+                    cell_to_format_id[cell_range_start] = fmt_id
+                else:
+                    cell_to_format_id[f"{cell_range_start}:{cell_range_end}"] = fmt_id
+                cell_range_start = cell
+                cell_range_end = None
+            else:
+                cell_range_start = cell
+                cell_range_end = cell
+            last_fmt = fmt_id
+
+        if cell_to_format_id:
+            sheet_formats[sheet.id] = cell_to_format_id
+
+        # Add the cell to note
+        cell_to_note = {cell: data["note"] for cell, data in cells.items() if "note" in data}
+        if cell_to_note:
+            sheet_notes[sheet.id] = cell_to_note
+
+        # Write values to .cogs/{sheet title}.tsv
         with open(f".cogs/{st}.tsv", "w") as f:
             lines = sheet.get_all_values()
             writer = csv.writer(f, delimiter="\t", lineterminator="\n")
@@ -87,6 +204,10 @@ def fetch(args):
 
     # Maybe update fields if they have changed
     maybe_update_fields(headers)
+
+    # Write or rewrite formats JSON with new dict
+    with open(".cogs/formats.json", "w") as f:
+        f.write(json.dumps(id_to_format, sort_keys=True, indent=4))
 
     # Update local sheets with new IDs
     all_sheets = []
@@ -98,25 +219,28 @@ def fetch(args):
         all_sheets.append(details)
 
     # Get all cached sheet titles that are not COGS defaults
-    cached_sheet_titles = []
-    for f in os.listdir(".cogs"):
-        if f not in ["user.tsv", "sheet.tsv", "field.tsv", "config.tsv", "renamed.tsv"]:
-            cached_sheet_titles.append(f.split(".")[0])
+    cached_sheet_titles = get_cached()
 
     # If a cached sheet title is not in sheet.tsv & not in remote sheets - remove it
     remote_titles = [x.title for x in sheets]
+    removed_ids = []
     for sheet_title in cached_sheet_titles:
         if sheet_title not in remote_titles and sheet_title not in new_local_titles:
             # This sheet has a cached copy but does not exist in the remote version
             # It has either been removed from remote or was newly added to cache
             if (
-                sheet_title in tracked_sheets
-                and tracked_sheets[sheet_title]["ID"].strip != ""
+                    sheet_title in tracked_sheets
+                    and tracked_sheets[sheet_title]["ID"].strip != ""
             ) or (sheet_title not in tracked_sheets):
                 # The sheet is in tracked sheets and has an ID (not newly added)
                 # or the sheet is not in tracked sheets
+                removed_ids.append(tracked_sheets[sheet_title]["ID"])
                 logging.info(f"Removing '{sheet_title}'")
                 os.remove(f".cogs/{sheet_title}.tsv")
+
+    # Rewrite format.tsv and note.tsv with current remote formats & notes
+    update_format(sheet_formats, removed_ids)
+    update_note(sheet_notes, removed_ids)
 
     # Get just the remote sheets that are not in local sheets
     new_sheets = {

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -119,7 +119,7 @@ def get_fields():
 
 
 def get_format_dict():
-    """"""
+    """Get a dict of numerical format ID -> the format dict."""
     if os.path.exists(".cogs/formats.json") and not os.stat(".cogs/formats.json").st_size == 0:
         with open(".cogs/formats.json", "r") as f:
             fmt_dict = json.loads(f.read())
@@ -128,7 +128,7 @@ def get_format_dict():
 
 
 def get_sheet_formats():
-    """"""
+    """Get a dict of sheet ID -> formatted cells."""
     sheet_to_formats = {}
     with open(".cogs/format.tsv") as f:
         reader = csv.DictReader(f, delimiter="\t")
@@ -146,7 +146,7 @@ def get_sheet_formats():
 
 
 def get_sheet_notes():
-    """"""
+    """Get a dict of sheet ID -> notes on cells."""
     sheet_to_notes = {}
     with open(".cogs/note.tsv") as f:
         reader = csv.DictReader(f, delimiter="\t")

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -1,6 +1,7 @@
 import csv
 import google.auth.exceptions
 import gspread
+import json
 import logging
 import os
 import pkg_resources
@@ -9,7 +10,9 @@ import re
 from cogs.exceptions import CogsError
 from daff import Coopy, CompareFlags, PythonTableView, TableDiff
 
-required_files = ["sheet.tsv", "field.tsv", "config.tsv"]
+reserved_names = ["format", "user", "config", "sheet", "field", "note", "renamed"]
+required_files = ["config.tsv", "field.tsv", "format.tsv", "note.tsv", "sheet.tsv"]
+optional_files = ["user.tsv", "renamed.tsv"]
 
 required_keys = ["Spreadsheet ID", "Title", "Credentials"]
 
@@ -18,7 +21,9 @@ def get_cached():
     """Return a list of cached sheets from .cogs."""
     cached = []
     for f in os.listdir(".cogs"):
-        if f not in ["user.tsv", "sheet.tsv", "field.tsv", "config.tsv", "renamed.tsv"]:
+        if not f.endswith("tsv"):
+            continue
+        if f not in required_files and f not in optional_files:
             cached.append(f.split(".")[0])
     return cached
 
@@ -88,15 +93,6 @@ def get_client(credentials):
             )
 
 
-def get_colstr(n):
-    """Transform an int (corresponding to a column) to a letter column for use in Google Sheets"""
-    string = ""
-    while n > 0:
-        n, remainder = divmod(n - 1, 26)
-        string = chr(65 + remainder) + string
-    return string
-
-
 def get_config():
     """Get the configuration for this project as a dict."""
     config = {}
@@ -120,6 +116,51 @@ def get_fields():
             del row["Field"]
             fields[field] = row
     return fields
+
+
+def get_format_dict():
+    """"""
+    if os.path.exists(".cogs/formats.json") and not os.stat(".cogs/formats.json").st_size == 0:
+        with open(".cogs/formats.json", "r") as f:
+            fmt_dict = json.loads(f.read())
+            return {int(k): v for k, v in fmt_dict.items()}
+    return {}
+
+
+def get_sheet_formats():
+    """"""
+    sheet_to_formats = {}
+    with open(".cogs/format.tsv") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            sheet = int(row["Sheet ID"])
+            cell = row["Cell"]
+            fmt = int(row["Format ID"])
+            if sheet in sheet_to_formats:
+                cell_to_format = sheet_to_formats[sheet]
+            else:
+                cell_to_format = {}
+            cell_to_format[cell] = fmt
+            sheet_to_formats[sheet] = cell_to_format
+    return sheet_to_formats
+
+
+def get_sheet_notes():
+    """"""
+    sheet_to_notes = {}
+    with open(".cogs/note.tsv") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            sheet = int(row["Sheet ID"])
+            cell = row["Cell"]
+            note = row["Note"]
+            if sheet in sheet_to_notes:
+                cell_to_note = sheet_to_notes[sheet]
+            else:
+                cell_to_note = {}
+            cell_to_note[cell] = note
+            sheet_to_notes[sheet] = cell_to_note
+    return sheet_to_notes
 
 
 def get_renamed():
@@ -213,6 +254,52 @@ def set_logging(verbose):
         logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     else:
         logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+
+
+def update_format(sheet_formats, removed_ids):
+    """Update format.tsv with current remote formatting.
+    Remove any lines with a Sheet ID in removed_ids."""
+    current_sheet_formats = get_sheet_formats()
+    fmt_rows = []
+    for sheet, formats in sheet_formats.items():
+        current_sheet_formats[sheet] = formats
+    for sheet, formats in current_sheet_formats.items():
+        if sheet in removed_ids:
+            continue
+        for cell, fmt in formats.items():
+            fmt_rows.append({"Sheet ID": sheet, "Cell": cell, "Format ID": fmt})
+    with open(".cogs/format.tsv", "w") as f:
+        writer = csv.DictWriter(
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["Sheet ID", "Cell", "Format ID"],
+        )
+        writer.writeheader()
+        writer.writerows(fmt_rows)
+
+
+def update_note(sheet_notes, removed_ids):
+    """Update note.tsv with current remote notes.
+    Remove any lines with a Sheet ID in removed_ids."""
+    current_sheet_notes = get_sheet_notes()
+    note_rows = []
+    for sheet, notes in sheet_notes.items():
+        current_sheet_notes[sheet] = notes
+    for sheet, notes in current_sheet_notes.items():
+        if sheet in removed_ids:
+            continue
+        for cell, note in notes.items():
+            note_rows.append({"Sheet ID": sheet, "Cell": cell, "Note": note})
+    with open(".cogs/note.tsv", "w") as f:
+        writer = csv.DictWriter(
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["Sheet ID", "Cell", "Note"],
+        )
+        writer.writeheader()
+        writer.writerows(note_rows)
 
 
 def validate_cogs_project():

--- a/src/cogs/init.py
+++ b/src/cogs/init.py
@@ -130,6 +130,26 @@ def write_data(args, sheet):
         writer.writeheader()
         writer.writerows(default_fields)
 
+    # format.tsv contains all cells with formats -> format IDs
+    with open(".cogs/format.tsv", "w") as f:
+        writer = csv.DictWriter(
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["Sheet ID", "Cell", "Format ID"],
+        )
+        writer.writeheader()
+
+    # note.tsv contains all cells with notes -> note
+    with open(".cogs/note.tsv", "w") as f:
+        writer = csv.DictWriter(
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["Sheet ID", "Cell", "Note"],
+        )
+        writer.writeheader()
+
 
 def init(args):
     """Init a new .cogs configuration directory in the current working directory. If one already

--- a/src/cogs/rm.py
+++ b/src/cogs/rm.py
@@ -93,17 +93,13 @@ def rm(args):
                 items["Field"] = field
                 writer.writerow(items)
 
-    # Check for notes to remove
-    sheet_notes = get_sheet_notes()
-    update = any((True for sheet_id in sheet_notes.keys() if sheet_id in ids_to_remove))
-    if update:
-        update_note(sheet_notes, ids_to_remove)
-
-    # Check for formats to remove
+    # Update formats and notes
     sheet_formats = get_sheet_formats()
-    update = any((True for sheet_id in sheet_formats.keys() if sheet_id in ids_to_remove))
-    if update:
-        update_format(sheet_formats, ids_to_remove)
+    update_format(sheet_formats, ids_to_remove)
+
+    sheet_notes = get_sheet_notes()
+    update_note(sheet_notes, ids_to_remove)
+
 
 
 def run(args):


### PR DESCRIPTION
Resolves #12 (adding `format.tsv` and `formats.json`) and adds support for notes with a special `note.tsv` file.

This impacts three functions:
- `fetch`: all formats and notes are added, new formats are added to `formats.json` with a numerical ID
- `push`: all formats and notes are applied to remote sheet
- `rm`: remove any formats/notes on cells in the removed sheet from `format.tsv` and `note.tsv`

At this time, I didn't remove any of the formats from the `.cogs/formats.json` file (where we track format ID -> the format) when a sheet is removed. Would we like to do this?

Additionally, there's no support for diffing formats (yet).