### PR TITLE
Add `ls` command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "3.7"
+cache: pip
+install:
+  - pip install -r requirements.txt
+script:
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ python:
 cache: pip
 install:
   - pip install -r requirements.txt
+  - python3 setup.py install
 script:
   - pytest

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ we try to follow the familiar `git` interface and workflow:
 - [`cogs push`](#push) pushes changes to local sheets to the project spreadsheet
 - [`cogs fetch`](#fetch) fetches the data from the spreadsheet and stores it in `.cogs/`
 - [`cogs mv foo.tsv bar.tsv`](#mv) updates the path to the local version of a spreadsheet from `foo.tsv` to `bar.tsv`
+- [`cogs ls`](#ls) shows a list of currently-tracked sheet names and their local names
 - [`cogs status`](#status) summarizes the differences between tracked files and their copies in `.cogs/`
 - [`cogs diff`](#diff) shows detailed differences between local files and the spreadsheet
 - [`cogs pull`](#pull) overwrites local files with the data from the spreadsheet, if they have changed
@@ -169,6 +170,14 @@ Three files are created in the `.cogs/` directory when running `init`:
 - `sheet.tsv`: Sheet names in spreadsheet and details (empty) - the sheets correspond to local tables
 
 All other tasks will fail if a COGS project has not been initialized in the working directory.
+
+### `ls`
+
+Running `ls` displays a list of tracked sheet names and their local paths, even if the local path does not yet exist.
+
+```
+cogs ls
+```
 
 ### `open`
 

--- a/src/cogs/add.py
+++ b/src/cogs/add.py
@@ -5,7 +5,7 @@ import re
 import sys
 
 from cogs.exceptions import CogsError, AddError
-from cogs.helpers import get_fields, get_sheets, set_logging, validate_cogs_project
+from cogs.helpers import get_fields, get_tracked_sheets, set_logging, validate_cogs_project
 
 
 def add(args):
@@ -33,7 +33,7 @@ def add(args):
         raise AddError(f"sheet cannot use reserved name '{title}'")
 
     # Make sure we aren't duplicating a table
-    local_sheets = get_sheets()
+    local_sheets = get_tracked_sheets()
     if title in local_sheets:
         raise AddError(f"'{title}' sheet already exists in this project")
 

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -8,6 +8,7 @@ import cogs.diff as diff
 import cogs.fetch as fetch
 import cogs.helpers as helpers
 import cogs.init as init
+import cogs.ls as ls
 import cogs.mv as mv
 import cogs.open as open
 import cogs.pull as pull
@@ -66,6 +67,10 @@ def main():
     )
     sp.add_argument("-U", "--users", help="TSV containing user emails and their roles")
     sp.set_defaults(func=init.run)
+
+    # ------------------------------- ls -------------------------------
+    sp = subparsers.add_parser("ls", parents=[global_parser])
+    sp.set_defaults(func=ls.run)
 
     # ------------------------------- mv -------------------------------
     sp = subparsers.add_parser("mv", parents=[global_parser])

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-import sys
-
 import cogs.add as add
 import cogs.delete as delete
 import cogs.diff as diff
@@ -24,7 +22,6 @@ def version(args):
     """Print COGS version information."""
     v = helpers.get_version()
     print(f"COGS version {v}")
-    sys.exit(0)
 
 
 def main():

--- a/src/cogs/diff.py
+++ b/src/cogs/diff.py
@@ -5,7 +5,7 @@ import sys
 import tabulate
 
 from cogs.exceptions import CogsError, DiffError
-from cogs.helpers import get_diff, get_sheets, set_logging, validate_cogs_project
+from cogs.helpers import get_diff, get_tracked_sheets, set_logging, validate_cogs_project
 
 
 def close_screen(stdscr):
@@ -66,7 +66,7 @@ def diff(args):
     set_logging(args.verbose)
     validate_cogs_project()
 
-    sheets = get_sheets()
+    sheets = get_tracked_sheets()
     paths = [details["Path"] for details in sheets.values()]
     if args.paths:
         for p in args.paths:

--- a/src/cogs/fetch.py
+++ b/src/cogs/fetch.py
@@ -7,8 +7,8 @@ from cogs.exceptions import CogsError, FetchError
 from cogs.helpers import (
     get_config,
     get_client,
-    get_renamed,
-    get_sheets,
+    get_renamed_sheets,
+    get_tracked_sheets,
     maybe_update_fields,
     set_logging,
     validate_cogs_project,
@@ -44,13 +44,13 @@ def fetch(args):
     # Get the remote sheets from spreadsheet
     sheets = spreadsheet.worksheets()
     remote_sheets = get_remote_sheets(sheets)
-    tracked_sheets = get_sheets()
+    tracked_sheets = get_tracked_sheets()
     id_to_title = {
         int(details["ID"]): sheet_title for sheet_title, details in tracked_sheets.items()
     }
 
     # Get details about renamed sheets
-    renamed_local = get_renamed()
+    renamed_local = get_renamed_sheets()
     new_local_titles = [details["new"] for details in renamed_local.values()]
     renamed_remote = {}
 

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -14,56 +14,15 @@ required_files = ["sheet.tsv", "field.tsv", "config.tsv"]
 required_keys = ["Spreadsheet ID", "Title", "Credentials"]
 
 
-def get_cached():
-    """Return a list of cached sheets from .cogs."""
+def get_cached_sheets():
+    """Return a list of names of cached sheets from .cogs. These are any sheets that have been
+    downloaded from the remote spreadsheet into the .cogs directory as TSVs. They may or may not be
+    tracked in sheet.tsv."""
     cached = []
     for f in os.listdir(".cogs"):
         if f not in ["user.tsv", "sheet.tsv", "field.tsv", "config.tsv", "renamed.tsv"]:
             cached.append(f.split(".")[0])
     return cached
-
-
-def get_diff(local, remote):
-    """Return the diff between a local and remote sheet as a list of lines with formatting. The
-       remote table is the 'old' version and the local table is the 'new' version."""
-    local_data = []
-    with open(local, "r") as f:
-        # Local might be CSV or TSV
-        if local.endswith("csv"):
-            reader = csv.reader(f)
-        else:
-            reader = csv.reader(f, delimiter="\t")
-        header = next(reader)
-        local_data.append(header)
-        for row in reader:
-            if len(row) < len(header):
-                add = [''] * (len(header) - len(row))
-                row.extend(add)
-            local_data.append(row)
-
-    remote_data = []
-    with open(remote, "r") as f:
-        # Remote is always TSV
-        reader = csv.reader(f, delimiter="\t")
-        header = next(reader)
-        remote_data.append(header)
-        for row in reader:
-            if len(row) < len(header):
-                add = [''] * (len(header) - len(row))
-                row.extend(add)
-            remote_data.append(row)
-
-    local_table = PythonTableView(local_data)
-    remote_table = PythonTableView(remote_data)
-    align = Coopy.compareTables(remote_table, local_table).align()
-
-    data_diff = []
-    table_diff = PythonTableView(data_diff)
-    flags = CompareFlags()
-    highlighter = TableDiff(align, flags)
-    highlighter.hilite(table_diff)
-
-    return data_diff
 
 
 def get_client(credentials):
@@ -110,8 +69,51 @@ def get_config():
     return config
 
 
+def get_diff(local, remote):
+    """Return the diff between a local and remote sheet as a list of lines with formatting. The
+       remote table is the 'old' version and the local table is the 'new' version."""
+    local_data = []
+    with open(local, "r") as f:
+        # Local might be CSV or TSV
+        if local.endswith("csv"):
+            reader = csv.reader(f)
+        else:
+            reader = csv.reader(f, delimiter="\t")
+        header = next(reader)
+        local_data.append(header)
+        for row in reader:
+            if len(row) < len(header):
+                add = [""] * (len(header) - len(row))
+                row.extend(add)
+            local_data.append(row)
+
+    remote_data = []
+    with open(remote, "r") as f:
+        # Remote is always TSV
+        reader = csv.reader(f, delimiter="\t")
+        header = next(reader)
+        remote_data.append(header)
+        for row in reader:
+            if len(row) < len(header):
+                add = [""] * (len(header) - len(row))
+                row.extend(add)
+            remote_data.append(row)
+
+    local_table = PythonTableView(local_data)
+    remote_table = PythonTableView(remote_data)
+    align = Coopy.compareTables(remote_table, local_table).align()
+
+    data_diff = []
+    table_diff = PythonTableView(data_diff)
+    flags = CompareFlags()
+    highlighter = TableDiff(align, flags)
+    highlighter.hilite(table_diff)
+
+    return data_diff
+
+
 def get_fields():
-    """Get the current fields in this project from field.tsv."""
+    """Get the current fields in this project from field.tsv as a dict of field name -> details."""
     fields = {}
     with open(".cogs/field.tsv", "r") as f:
         reader = csv.DictReader(f, delimiter="\t")
@@ -122,8 +124,8 @@ def get_fields():
     return fields
 
 
-def get_renamed():
-    """Get a set of renamed sheets from renamed.tsv."""
+def get_renamed_sheets():
+    """Get a set of renamed sheets from renamed.tsv as a dict of old name -> new name & path."""
     renamed = {}
     if os.path.exists(".cogs/renamed.tsv"):
         with open(".cogs/renamed.tsv", "r") as f:
@@ -136,8 +138,9 @@ def get_renamed():
     return renamed
 
 
-def get_sheets():
-    """Get the current local sheets in this project from sheet.tsv."""
+def get_tracked_sheets():
+    """Get the current tracked sheets in this project from sheet.tsv as a dict of sheet title ->
+    path & ID. They may or may not have corresponding cached/local sheets."""
     sheets = {}
     with open(".cogs/sheet.tsv", "r") as f:
         reader = csv.DictReader(f, delimiter="\t")
@@ -175,7 +178,9 @@ def maybe_update_fields(headers):
     fields = get_fields()
     update_fields = False
     # Determine if fields were removed
-    new_fields = {re.sub(r"[^A-Za-z0-9]+", "_", h.lower()).strip("_"): h for h in headers}
+    new_fields = {
+        re.sub(r"[^A-Za-z0-9]+", "_", h.lower()).strip("_"): h for h in headers
+    }
     remove_fields = [f for f in fields.keys() if f not in new_fields.keys()]
     if remove_fields:
         update_fields = True

--- a/src/cogs/ls.py
+++ b/src/cogs/ls.py
@@ -1,0 +1,26 @@
+import sys
+import tabulate
+
+from cogs.helpers import *
+
+
+def ls(args):
+    """Print a list of tracked files"""
+    set_logging(args.verbose)
+    validate_cogs_project()
+
+    tracked_sheets = get_tracked_sheets()
+    sheet_details = []
+    for sheet, details in tracked_sheets.items():
+        sheet_details.append([sheet, "(" + details["Path"] + ")"])
+
+    print(tabulate.tabulate(sheet_details, tablefmt="plain"))
+
+
+def run(args):
+    """Wrapper for fetch function."""
+    try:
+        ls(args)
+    except CogsError as e:
+        logging.critical(str(e))
+        sys.exit(1)

--- a/src/cogs/mv.py
+++ b/src/cogs/mv.py
@@ -6,7 +6,7 @@ import shutil
 import sys
 
 from cogs.exceptions import CogsError, MvError
-from cogs.helpers import get_sheets, set_logging, validate_cogs_project
+from cogs.helpers import get_tracked_sheets, set_logging, validate_cogs_project
 
 
 def mv(args):
@@ -29,7 +29,7 @@ def mv(args):
             sys.exit(0)
 
     # Get the tracked sheets
-    tracked_sheets = get_sheets()
+    tracked_sheets = get_tracked_sheets()
     path_to_sheet = {
         os.path.abspath(details["Path"]): sheet_title
         for sheet_title, details in tracked_sheets.items()

--- a/src/cogs/pull.py
+++ b/src/cogs/pull.py
@@ -4,7 +4,7 @@ import shutil
 import sys
 
 from cogs.exceptions import CogsError
-from cogs.helpers import get_cached, get_sheets, set_logging, validate_cogs_project
+from cogs.helpers import get_cached_sheets, get_tracked_sheets, set_logging, validate_cogs_project
 
 
 def pull(args):
@@ -12,8 +12,8 @@ def pull(args):
     set_logging(args.verbose)
     validate_cogs_project()
 
-    cached_sheets = get_cached()
-    tracked_sheets = get_sheets()
+    cached_sheets = get_cached_sheets()
+    tracked_sheets = get_tracked_sheets()
     remove_sheets = [s for s in cached_sheets if s not in tracked_sheets.keys()]
     for sheet_title, details in tracked_sheets.items():
         cached_sheet = f".cogs/{sheet_title}.tsv"

--- a/src/cogs/push.py
+++ b/src/cogs/push.py
@@ -8,8 +8,8 @@ from cogs.helpers import (
     get_client,
     get_colstr,
     get_config,
-    get_renamed,
-    get_sheets,
+    get_renamed_sheets,
+    get_tracked_sheets,
     maybe_update_fields,
     set_logging,
     validate_cogs_project,
@@ -28,8 +28,8 @@ def push(args):
     spreadsheet = gc.open(config["Title"])
 
     # Get tracked sheets
-    tracked_sheets = get_sheets()
-    renamed_local = get_renamed()
+    tracked_sheets = get_tracked_sheets()
+    renamed_local = get_renamed_sheets()
 
     # Clear existing sheets (wait to delete any that were removed)
     # If we delete first, could throw error where we try to delete the last remaining ws

--- a/src/cogs/rm.py
+++ b/src/cogs/rm.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 from cogs.exceptions import CogsError, RmError
-from cogs.helpers import get_fields, get_sheets, set_logging, validate_cogs_project
+from cogs.helpers import get_fields, get_tracked_sheets, set_logging, validate_cogs_project
 
 
 def rm(args):
@@ -14,7 +14,7 @@ def rm(args):
     validate_cogs_project()
 
     # Make sure the sheets exist
-    sheets = get_sheets()
+    sheets = get_tracked_sheets()
 
     paths = [sheet["Path"] for sheet in sheets.values()]
     if len(set(args.paths) - set(paths)) > 0:

--- a/src/cogs/status.py
+++ b/src/cogs/status.py
@@ -5,10 +5,10 @@ import termcolor
 
 from cogs.exceptions import CogsError
 from cogs.helpers import (
-    get_cached,
+    get_cached_sheets,
     get_diff,
-    get_renamed,
-    get_sheets,
+    get_renamed_sheets,
+    get_tracked_sheets,
     set_logging,
     validate_cogs_project,
 )
@@ -17,7 +17,7 @@ from cogs.helpers import (
 def get_changes(tracked_sheets, renamed):
     """Get sets of changes between local and remote sheets."""
     # Get all cached sheet titles that are not COGS defaults
-    cached_sheet_titles = get_cached()
+    cached_sheet_titles = get_cached_sheets()
 
     # Get all tracked sheet titles
     tracked_sheet_titles = list(tracked_sheets.keys())
@@ -196,8 +196,8 @@ def status(args):
     validate_cogs_project()
 
     # Get the sets of changes
-    tracked_sheets = get_sheets()
-    renamed = get_renamed()
+    tracked_sheets = get_tracked_sheets()
+    renamed = get_renamed_sheets()
     diffs, added_local, added_remote, removed_local, removed_remote = get_changes(
         tracked_sheets, renamed
     )

--- a/tests/test_cogs.py
+++ b/tests/test_cogs.py
@@ -1,0 +1,25 @@
+import importlib.util
+
+
+def test_modules():
+    """Test that modules are properly loaded."""
+    for module in [
+        "add",
+        "delete",
+        "diff",
+        "exceptions",
+        "fetch",
+        "helpers",
+        "init",
+        "ls",
+        "mv",
+        "open",
+        "pull",
+        "push",
+        "rm",
+        "share",
+        "status",
+    ]:
+        spec = importlib.util.find_spec("cogs." + module)
+        if not spec:
+            raise Exception(f"cogs.{module} does not exist")


### PR DESCRIPTION
Resolves #36 

Some of the helper functions had unclear names, so I updated these which is why there are changes in multiple files.
* `get_cached()` -> `get_cached_sheets()`
* `get_renamed()` -> `get_renamed_sheets()`
* `get_sheets()` -> `get_tracked_sheets()`

---

### `ls`

Running `ls` displays a list of tracked sheet names and their local paths, even if the local path does not yet exist.

```
cogs ls
```