### PR TITLE
Add 'apply' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ Running `apply` applies the details of [standardized problems]() from [ROBOT val
 cogs apply [problems_table]
 ```
 
-ROBOT has three levels of problems which will be formatted as such:
-* **error**: red background with white text
-* **warn/warning**: yellow background
+ROBOT has three levels of problems which will be formatted with a black border and the following backgrounds:
+* **error**: light red background
+* **warn/warning**: light yellow background
 * **info**: light blue background
 
-The formats will be added to any existing formats, but will take priority over the existing formats.
+The notes and formats will be added to any existing, but will take priority over the existing notes and formats.
 
-The "rule name" value from the standardized problems table will become the note on the cell. All existing notes on a sheet will be overwritten and replaced with the notes from `apply`.
+Running `apply` again will remove any "applied" formats and notes from the last time `apply` was run and add new details from the current problems table. To erase all "applied" formats and notes, run `cogs apply` with no additional arguments. Existing formats and notes added by the user will not be removed.
 
 ### `delete`
 

--- a/README.md
+++ b/README.md
@@ -11,18 +11,22 @@ Since COGS is designed to synchronize local and remote sets of tables,
 we try to follow the familiar `git` interface and workflow:
 
 - [`cogs init`](#init) creates a `.cogs/` directory to store configuration data and creates a spreadsheet for the project
-- [`cogs open`](#open) displays the URL of the spreadsheet
-- [`cogs share`](#share) shares the spreadsheet with specified users
 - [`cogs add foo.tsv`](#add) starts tracking the `foo.tsv` table as a sheet
 - [`cogs rm foo.tsv`](#rm) stops tracking the `foo.tsv` table as a sheet
 - [`cogs push`](#push) pushes changes to local sheets to the project spreadsheet
 - [`cogs fetch`](#fetch) fetches the data from the spreadsheet and stores it in `.cogs/`
-- [`cogs mv foo.tsv bar.tsv`](#mv) updates the path to the local version of a spreadsheet from `foo.tsv` to `bar.tsv`
 - [`cogs ls`](#ls) shows a list of currently-tracked sheet names and their local names
 - [`cogs status`](#status) summarizes the differences between tracked files and their copies in `.cogs/`
 - [`cogs diff`](#diff) shows detailed differences between local files and the spreadsheet
 - [`cogs pull`](#pull) overwrites local files with the data from the spreadsheet, if they have changed
+
+There are some other commands that do not correspond to any `git` actions:
+
+- [`cogs apply`](#apply) applys formatting & notes to the spreadsheet from a standardized table
 - [`cogs delete`](#delete) destroys the spreadsheet and configuration data, but leaves local files alone
+- [`cogs mv foo.tsv bar.tsv`](#mv) updates the path to the local version of a spreadsheet from `foo.tsv` to `bar.tsv`
+- [`cogs open`](#open) displays the URL of the spreadsheet
+- [`cogs share`](#share) shares the spreadsheet with specified users
 
 There is no step corresponding to `git commit`.
 
@@ -85,6 +89,23 @@ The `-d`/`--description` is optional.
 The sheet title is created from the path (e.g., `tables/foo.tsv` will be named `foo`). If a sheet with this title already exists in the project, the task will fail. The sheet/file name cannot be one of the COGS reserved names: `config`, `field`, `sheet`, `renamed`, or `user`.
 
 This does not add the table to the spreadsheet as a sheet - use `cogs push` to push all tracked local tables to the project spreadsheet.
+
+### `apply`
+<!-- TODO: ROBOT page describing error tables? -->
+Running `apply` applies the details of [standardized problems]() from [ROBOT validate](http://robot.obolibrary.org/validate) or [ROBOT template](http://robot.obolibrary.org/template) to the spreadsheet as cell formatting and notes.
+
+```
+cogs apply [problems_table]
+```
+
+ROBOT has three levels of problems which will be formatted as such:
+* **error**: red background with white text
+* **warn/warning**: yellow background
+* **info**: light blue background
+
+The formats will be added to any existing formats, but will take priority over the existing formats.
+
+The "rule name" value from the standardized problems table will become the note on the cell. All existing notes on a sheet will be overwritten and replaced with the notes from `apply`.
 
 ### `delete`
 

--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ The sheet title is created from the path (e.g., `tables/foo.tsv` will be named `
 This does not add the table to the spreadsheet as a sheet - use `cogs push` to push all tracked local tables to the project spreadsheet.
 
 ### `apply`
-<!-- TODO: ROBOT page describing error tables? -->
-Running `apply` applies the details of [standardized problems]() from [ROBOT validate](http://robot.obolibrary.org/validate) or [ROBOT template](http://robot.obolibrary.org/template) to the spreadsheet as cell formatting and notes.
+
+Running `apply` applies the details of [standardized problems tables](#standardized-problems-tables) to the spreadsheet as cell formatting and notes.
 
 ```
 cogs apply [problems_table]
 ```
 
-ROBOT has three levels of problems which will be formatted with a black border and the following backgrounds:
+The three levels of problems will be formatted with a black border and the following backgrounds:
 * **error**: light red background
 * **warn/warning**: light yellow background
 * **info**: light blue background
@@ -106,6 +106,20 @@ ROBOT has three levels of problems which will be formatted with a black border a
 The notes and formats will be added to any existing, but will take priority over the existing notes and formats.
 
 Running `apply` again will remove any "applied" formats and notes from the last time `apply` was run and add new details from the current problems table. To erase all "applied" formats and notes, run `cogs apply` with no additional arguments. Existing formats and notes added by the user will not be removed.
+
+#### Standardized Problems Tables
+
+Standardized problems tables provide a standard table output that can be converted into formatting and notes in the spreadsheet using `apply`. As long as the table follows the format described below, any type of problem can be applied to the sheets. One example is the errors from [ROBOT template](http://robot.obolibrary.org/template).
+
+These tables must have the following headers:
+* **ID**: local numeric identifier starting at 1 and counting up
+* **table**: name of the table that the problem occurs in
+* **cell**: A1 format of problematic cell location
+* **level**: severity of the problem; error, warn, or info - this determines the background color of the cell
+* **rule ID**: an IRI or CURIE to uniquely identify the problem
+* **rule name**: descriptive name of the problem - this is converted to the cell note
+* **value**: value of the cell causing problem
+* **fix**: can be left blank; a suggestion of how to fix the problem
 
 ### `delete`
 
@@ -292,3 +306,4 @@ There are five kinds of statuses (note that any changes to the remote spreadshee
     * use `cogs push` to remove the sheet from the remote spreadsheet
 * **Removed remotely**: the sheet exists locally but has been removed from remote spreadsheet
     * use `cogs pull` to remove the sheet locally
+

--- a/src/cogs/apply.py
+++ b/src/cogs/apply.py
@@ -11,7 +11,7 @@ from cogs.helpers import (
     set_logging,
     validate_cogs_project,
     update_format,
-    update_note
+    update_note,
 )
 
 
@@ -23,7 +23,37 @@ def apply(args):
 
     # Get existing formats
     sheet_to_formats = get_sheet_formats()
-    sheet_to_notes = {}
+
+    # Remove any formats that are "applied" (format ID 0, 1, or 2)
+    sheet_to_manual_formats = {}
+    for sheet_title, cell_to_formats in sheet_to_formats.items():
+        manual_formats = {}
+        for cell, fmt in cell_to_formats.items():
+            if int(fmt) > 2:
+                manual_formats[cell] = fmt
+            sheet_to_manual_formats[sheet_title] = manual_formats
+    sheet_to_formats = sheet_to_manual_formats
+
+    # Remove any notes that are "applied" (starts with ERROR, WARN, or INFO)
+    sheet_to_notes = get_sheet_notes()
+    sheet_to_manual_notes = {}
+    for sheet_title, cell_to_notes in sheet_to_notes.items():
+        manual_notes = {}
+        for cell, note in cell_to_notes.items():
+            if (
+                not note.startswith("ERROR: ")
+                and not note.startswith("WARN: ")
+                and not note.startswith("INFO: ")
+            ):
+                manual_notes[cell] = note
+        sheet_to_manual_notes[sheet_title] = manual_notes
+    sheet_to_notes = sheet_to_manual_notes
+
+    if not args.problems_table:
+        # No table provided - update without adding anything else
+        update_note(sheet_to_notes, [])
+        update_format(sheet_to_formats, [])
+        return
 
     # Read the problems table to get the formats & notes to add
     sep = "\t"
@@ -49,17 +79,41 @@ def apply(args):
                 cell_to_notes = {}
 
             cell = row["cell"].upper()
+
+            # Check for current applied formats and/or notes
+            current_fmt = -1
+            current_note = None
+            if cell in cell_to_formats and int(cell_to_formats[cell]) <= 2:
+                current_fmt = cell_to_formats[cell]
+            if cell in cell_to_notes:
+                current_note = cell_to_notes[cell]
+                if (
+                    not current_note.startswith("ERROR: ")
+                    and not current_note.startswith("WARN: ")
+                    and not current_note.startswith("INFO: ")
+                ):
+                    # Not an applied note
+                    current_note = None
+
+            # Set formatting based on level of issue
             level = row["level"].lower().strip()
             if level == "error":
                 cell_to_formats[cell] = 0
             elif level == "warn" or level == "warning":
-                cell_to_formats[cell] = 1
+                level = "warn"
+                if current_fmt != 0:
+                    cell_to_formats[cell] = 1
             elif level == "info":
-                cell_to_formats[cell] = 2
+                if current_fmt > 1:
+                    cell_to_formats[cell] = 2
 
+            # Add the note
             rule_name = row["rule name"]
-            logging.info(f"Adding \"{rule_name}\" to {cell} as a(n) {level}")
-            cell_to_notes[cell] = rule_name
+            logging.info(f'Adding "{rule_name}" to {cell} as a(n) {level}')
+            if current_note:
+                cell_to_notes[cell] = f"{current_note}\n\n{level.upper()}: {rule_name}"
+            else:
+                cell_to_notes[cell] = f"{level.upper()}: {rule_name}"
 
             sheet_to_formats[table] = cell_to_formats
             sheet_to_notes[table] = cell_to_notes

--- a/src/cogs/apply.py
+++ b/src/cogs/apply.py
@@ -1,0 +1,78 @@
+import csv
+import logging
+import os
+import sys
+
+from cogs.exceptions import CogsError
+from cogs.helpers import (
+    get_sheet_formats,
+    get_sheet_notes,
+    get_tracked_sheets,
+    set_logging,
+    validate_cogs_project,
+    update_format,
+    update_note
+)
+
+
+def apply(args):
+    """Apply a standardized ROBOT problems table to the spreadsheet."""
+    validate_cogs_project()
+    set_logging(args.verbose)
+    tracked_sheets = get_tracked_sheets()
+
+    # Get existing formats
+    sheet_to_formats = get_sheet_formats()
+    sheet_to_notes = {}
+
+    # Read the problems table to get the formats & notes to add
+    sep = "\t"
+    if args.problems_table.endswith(".csv"):
+        sep = ","
+    with open(args.problems_table, "r") as f:
+        reader = csv.DictReader(f, delimiter=sep)
+        for row in reader:
+            table = os.path.splitext(os.path.basename(row["table"]))[0]
+            if table not in tracked_sheets:
+                # TODO - error? warning?
+                logging.warning(f"'{table} is not a tracked table")
+                continue
+
+            if table in sheet_to_formats:
+                cell_to_formats = sheet_to_formats[table]
+            else:
+                cell_to_formats = {}
+
+            if table in sheet_to_notes:
+                cell_to_notes = sheet_to_notes[table]
+            else:
+                cell_to_notes = {}
+
+            cell = row["cell"].upper()
+            level = row["level"].lower().strip()
+            if level == "error":
+                cell_to_formats[cell] = 0
+            elif level == "warn" or level == "warning":
+                cell_to_formats[cell] = 1
+            elif level == "info":
+                cell_to_formats[cell] = 2
+
+            rule_name = row["rule name"]
+            logging.info(f"Adding \"{rule_name}\" to {cell} as a(n) {level}")
+            cell_to_notes[cell] = rule_name
+
+            sheet_to_formats[table] = cell_to_formats
+            sheet_to_notes[table] = cell_to_notes
+
+    # Update formats & notes TSVs
+    update_note(sheet_to_notes, [])
+    update_format(sheet_to_formats, [])
+
+
+def run(args):
+    """Wrapper for apply function."""
+    try:
+        apply(args)
+    except CogsError as e:
+        logging.critical(str(e))
+        sys.exit(1)

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import cogs.add as add
+import cogs.apply as apply
 import cogs.delete as delete
 import cogs.diff as diff
 import cogs.fetch as fetch
@@ -38,6 +39,11 @@ def main():
     sp.add_argument("path", help="Path to TSV or CSV to add to COGS project")
     sp.add_argument("-d", "--description", help="Description of sheet to add to spreadsheet")
     sp.set_defaults(func=add.run)
+
+    # ------------------------------- apply -------------------------------
+    sp = subparsers.add_parser("apply", parents=[global_parser])
+    sp.add_argument("problems_table", help="Path to ROBOT standardized problems table")
+    sp.set_defaults(func=apply.run)
 
     # ------------------------------- delete -------------------------------
     sp = subparsers.add_parser("delete", parents=[global_parser])

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -42,7 +42,7 @@ def main():
 
     # ------------------------------- apply -------------------------------
     sp = subparsers.add_parser("apply", parents=[global_parser])
-    sp.add_argument("problems_table", help="Path to ROBOT standardized problems table")
+    sp.add_argument("problems_table", nargs="?", default=None, help="Path to ROBOT standardized problems table")
     sp.set_defaults(func=apply.run)
 
     # ------------------------------- delete -------------------------------

--- a/src/cogs/fetch.py
+++ b/src/cogs/fetch.py
@@ -39,9 +39,6 @@ def get_cell_data(sheet):
     return cells
 
 
-def get_formats():
-    pass
-
 def get_remote_sheets(sheets):
     """Retrieve a map of sheet title -> sheet ID from the spreadsheet."""
     # Validate sheet titles before downloading anything

--- a/src/cogs/fetch.py
+++ b/src/cogs/fetch.py
@@ -39,6 +39,9 @@ def get_cell_data(sheet):
     return cells
 
 
+def get_formats():
+    pass
+
 def get_remote_sheets(sheets):
     """Retrieve a map of sheet title -> sheet ID from the spreadsheet."""
     # Validate sheet titles before downloading anything
@@ -172,27 +175,32 @@ def fetch(args):
                 next_fmt_id += 1
 
             if last_fmt and fmt_id == last_fmt:
-                # Add to range
+                # The last cell had a format and the this cell's format is the same as the last
+                # so we increase the range
                 cell_range_end = cell
-            elif last_fmt and cell_range_start and cell_range_end:
-                if cell_range_start == cell_range_end:
-                    cell_to_format_id[cell_range_start] = fmt_id
+            elif last_fmt and fmt_id != last_fmt:
+                # The last cell had a format but it was different than the current format
+                if cell_range_start == cell_range_end or not cell_range_end:
+                    # Not a range, just a single cell (the previous cell)
+                    cell_to_format_id[cell_range_start] = last_fmt
                 else:
-                    cell_to_format_id[f"{cell_range_start}:{cell_range_end}"] = fmt_id
+                    cell_to_format_id[f"{cell_range_start}:{cell_range_end}"] = last_fmt
+                # Restarting a new range at this cell
                 cell_range_start = cell
                 cell_range_end = None
             else:
+                # No last formatting to compare to, start a new range
                 cell_range_start = cell
                 cell_range_end = cell
             last_fmt = fmt_id
 
         if cell_to_format_id:
-            sheet_formats[sheet.id] = cell_to_format_id
+            sheet_formats[st] = cell_to_format_id
 
         # Add the cell to note
         cell_to_note = {cell: data["note"] for cell, data in cells.items() if "note" in data}
         if cell_to_note:
-            sheet_notes[sheet.id] = cell_to_note
+            sheet_notes[st] = cell_to_note
 
         # Write values to .cogs/{sheet title}.tsv
         with open(f".cogs/{st}.tsv", "w") as f:
@@ -223,7 +231,7 @@ def fetch(args):
 
     # If a cached sheet title is not in sheet.tsv & not in remote sheets - remove it
     remote_titles = [x.title for x in sheets]
-    removed_ids = []
+    removed_titles = []
     for sheet_title in cached_sheet_titles:
         if sheet_title not in remote_titles and sheet_title not in new_local_titles:
             # This sheet has a cached copy but does not exist in the remote version
@@ -234,13 +242,13 @@ def fetch(args):
             ) or (sheet_title not in tracked_sheets):
                 # The sheet is in tracked sheets and has an ID (not newly added)
                 # or the sheet is not in tracked sheets
-                removed_ids.append(tracked_sheets[sheet_title]["ID"])
+                removed_titles.append(sheet_title)
                 logging.info(f"Removing '{sheet_title}'")
                 os.remove(f".cogs/{sheet_title}.tsv")
 
     # Rewrite format.tsv and note.tsv with current remote formats & notes
-    update_format(sheet_formats, removed_ids)
-    update_note(sheet_notes, removed_ids)
+    update_format(sheet_formats, removed_titles)
+    update_note(sheet_notes, removed_titles)
 
     # Get just the remote sheets that are not in local sheets
     new_sheets = {

--- a/src/cogs/helpers.py
+++ b/src/cogs/helpers.py
@@ -135,15 +135,15 @@ def get_sheet_formats():
     with open(".cogs/format.tsv") as f:
         reader = csv.DictReader(f, delimiter="\t")
         for row in reader:
-            sheet = int(row["Sheet ID"])
+            sheet_title = row["Sheet Title"]
             cell = row["Cell"]
             fmt = int(row["Format ID"])
-            if sheet in sheet_to_formats:
-                cell_to_format = sheet_to_formats[sheet]
+            if sheet_title in sheet_to_formats:
+                cell_to_format = sheet_to_formats[sheet_title]
             else:
                 cell_to_format = {}
             cell_to_format[cell] = fmt
-            sheet_to_formats[sheet] = cell_to_format
+            sheet_to_formats[sheet_title] = cell_to_format
     return sheet_to_formats
 
 
@@ -153,15 +153,15 @@ def get_sheet_notes():
     with open(".cogs/note.tsv") as f:
         reader = csv.DictReader(f, delimiter="\t")
         for row in reader:
-            sheet = int(row["Sheet ID"])
+            sheet_title = row["Sheet Title"]
             cell = row["Cell"]
             note = row["Note"]
-            if sheet in sheet_to_notes:
-                cell_to_note = sheet_to_notes[sheet]
+            if sheet_title in sheet_to_notes:
+                cell_to_note = sheet_to_notes[sheet_title]
             else:
                 cell_to_note = {}
             cell_to_note[cell] = note
-            sheet_to_notes[sheet] = cell_to_note
+            sheet_to_notes[sheet_title] = cell_to_note
     return sheet_to_notes
 
 
@@ -261,47 +261,47 @@ def set_logging(verbose):
         logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 
 
-def update_format(sheet_formats, removed_ids):
+def update_format(sheet_formats, removed_titles):
     """Update format.tsv with current remote formatting.
     Remove any lines with a Sheet ID in removed_ids."""
     current_sheet_formats = get_sheet_formats()
     fmt_rows = []
-    for sheet, formats in sheet_formats.items():
-        current_sheet_formats[sheet] = formats
-    for sheet, formats in current_sheet_formats.items():
-        if sheet in removed_ids:
+    for sheet_title, formats in sheet_formats.items():
+        current_sheet_formats[sheet_title] = formats
+    for sheet_title, formats in current_sheet_formats.items():
+        if sheet_title in removed_titles:
             continue
         for cell, fmt in formats.items():
-            fmt_rows.append({"Sheet ID": sheet, "Cell": cell, "Format ID": fmt})
+            fmt_rows.append({"Sheet Title": sheet_title, "Cell": cell, "Format ID": fmt})
     with open(".cogs/format.tsv", "w") as f:
         writer = csv.DictWriter(
             f,
             delimiter="\t",
             lineterminator="\n",
-            fieldnames=["Sheet ID", "Cell", "Format ID"],
+            fieldnames=["Sheet Title", "Cell", "Format ID"],
         )
         writer.writeheader()
         writer.writerows(fmt_rows)
 
 
-def update_note(sheet_notes, removed_ids):
+def update_note(sheet_notes, removed_titles):
     """Update note.tsv with current remote notes.
     Remove any lines with a Sheet ID in removed_ids."""
     current_sheet_notes = get_sheet_notes()
     note_rows = []
-    for sheet, notes in sheet_notes.items():
-        current_sheet_notes[sheet] = notes
-    for sheet, notes in current_sheet_notes.items():
-        if sheet in removed_ids:
+    for sheet_title, notes in sheet_notes.items():
+        current_sheet_notes[sheet_title] = notes
+    for sheet_title, notes in current_sheet_notes.items():
+        if sheet_title in removed_titles:
             continue
         for cell, note in notes.items():
-            note_rows.append({"Sheet ID": sheet, "Cell": cell, "Note": note})
+            note_rows.append({"Sheet Title": sheet_title, "Cell": cell, "Note": note})
     with open(".cogs/note.tsv", "w") as f:
         writer = csv.DictWriter(
             f,
             delimiter="\t",
             lineterminator="\n",
-            fieldnames=["Sheet ID", "Cell", "Note"],
+            fieldnames=["Sheet Title", "Cell", "Note"],
         )
         writer.writeheader()
         writer.writerows(note_rows)

--- a/src/cogs/init.py
+++ b/src/cogs/init.py
@@ -51,21 +51,97 @@ default_fields = [
 # 0 = error, 1 = warn, 2 = info
 default_formats = {
     "0": {
-        "backgroundColor": {"red": 1},
-        "backgroundColorStyle": {"rgbColor": {"red": 1}},
-        "textFormat": {
-            "foregroundColor": {"blue": 1, "green": 1, "red": 1},
-            "foregroundColorStyle": {"rgbColor": {"blue": 1, "green": 1, "red": 1}},
+        "backgroundColor": {"blue": 0.7019608, "green": 0.7019608, "red": 1},
+        "backgroundColorStyle": {
+            "rgbColor": {"blue": 0.7019608, "green": 0.7019608, "red": 1}
+        },
+        "borders": {
+            "bottom": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "left": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "right": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "top": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
         },
     },
     "1": {
-        "backgroundColor": {"green": 1, "red": 1},
-        "backgroundColorStyle": {"rgbColor": {"green": 1, "red": 1}},
+        "backgroundColor": {"blue": 0.5921569, "green": 1, "red": 1},
+        "backgroundColorStyle": {"rgbColor": {"blue": 0.5921569, "green": 1, "red": 1}},
+        "borders": {
+            "bottom": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "left": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "right": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "top": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+        },
     },
     "2": {
-        "backgroundColor": {"blue": 0.9529412, "green": 0.8862745, "red": 0.8117647},
+        "backgroundColor": {"blue": 1, "green": 0.87058824, "red": 0.7254902},
         "backgroundColorStyle": {
-            "rgbColor": {"blue": 0.9529412, "green": 0.8862745, "red": 0.8117647}
+            "rgbColor": {"blue": 1, "green": 0.87058824, "red": 0.7254902}
+        },
+        "borders": {
+            "bottom": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "left": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "right": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "top": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
         },
     },
 }

--- a/src/cogs/init.py
+++ b/src/cogs/init.py
@@ -1,5 +1,6 @@
 import csv
 import gspread
+import json
 import logging
 import os
 import sys
@@ -46,6 +47,28 @@ default_fields = [
         "Description": "The datatype for this row",
     },
 ]
+
+# 0 = error, 1 = warn, 2 = info
+default_formats = {
+    "0": {
+        "backgroundColor": {"red": 1},
+        "backgroundColorStyle": {"rgbColor": {"red": 1}},
+        "textFormat": {
+            "foregroundColor": {"blue": 1, "green": 1, "red": 1},
+            "foregroundColorStyle": {"rgbColor": {"blue": 1, "green": 1, "red": 1}},
+        },
+    },
+    "1": {
+        "backgroundColor": {"green": 1, "red": 1},
+        "backgroundColorStyle": {"rgbColor": {"green": 1, "red": 1}},
+    },
+    "2": {
+        "backgroundColor": {"blue": 0.9529412, "green": 0.8862745, "red": 0.8117647},
+        "backgroundColorStyle": {
+            "rgbColor": {"blue": 0.9529412, "green": 0.8862745, "red": 0.8117647}
+        },
+    },
+}
 
 
 def get_users(args):
@@ -136,9 +159,12 @@ def write_data(args, sheet):
             f,
             delimiter="\t",
             lineterminator="\n",
-            fieldnames=["Sheet ID", "Cell", "Format ID"],
+            fieldnames=["Sheet Title", "Cell", "Format ID"],
         )
         writer.writeheader()
+
+    with open(".cogs/formats.json", "w") as f:
+        f.write(json.dumps(default_formats, sort_keys=True, indent=4))
 
     # note.tsv contains all cells with notes -> note
     with open(".cogs/note.tsv", "w") as f:
@@ -146,7 +172,7 @@ def write_data(args, sheet):
             f,
             delimiter="\t",
             lineterminator="\n",
-            fieldnames=["Sheet ID", "Cell", "Note"],
+            fieldnames=["Sheet Title", "Cell", "Note"],
         )
         writer.writeheader()
 

--- a/src/cogs/push.py
+++ b/src/cogs/push.py
@@ -83,8 +83,7 @@ def push(args):
     sheet_notes = get_sheet_notes()
 
     # Add formatting
-    for sheet_id, cell_to_format in sheet_formats.items():
-        sheet_title = id_to_title[int(sheet_id)]
+    for sheet_title, cell_to_format in sheet_formats.items():
         sheet = spreadsheet.worksheet(sheet_title)
         formats = []
         for cell, fmt_id in cell_to_format.items():
@@ -94,8 +93,7 @@ def push(args):
         gf.format_cell_ranges(sheet, formats)
 
     # Add notes
-    for sheet_id, cell_to_note in sheet_notes.items():
-        sheet_title = id_to_title[int(sheet_id)]
+    for sheet_title, cell_to_note in sheet_notes.items():
         sheet = spreadsheet.worksheet(sheet_title)
         for cell, note in cell_to_note.items():
             add_note(sheet, cell, note)

--- a/src/cogs/rm.py
+++ b/src/cogs/rm.py
@@ -22,7 +22,6 @@ def rm(args):
     sheets_to_remove = {
         title: sheet for title, sheet in sheets.items() if sheet["Path"] in args.paths
     }
-    ids_to_remove = [sheet["ID"] for title, sheet in sheets.items() if sheet["Path"] in args.paths]
 
     # Make sure we are not deleting the last sheet as Google spreadsheet would refuse to do so
     if len(sheets) - len(sheets_to_remove) == 0:
@@ -95,11 +94,10 @@ def rm(args):
 
     # Update formats and notes
     sheet_formats = get_sheet_formats()
-    update_format(sheet_formats, ids_to_remove)
+    update_format(sheet_formats, sheets_to_remove.keys())
 
     sheet_notes = get_sheet_notes()
-    update_note(sheet_notes, ids_to_remove)
-
+    update_note(sheet_notes, sheets_to_remove.keys())
 
 
 def run(args):

--- a/tests/test_cogs.py
+++ b/tests/test_cogs.py
@@ -5,6 +5,7 @@ def test_modules():
     """Test that modules are properly loaded."""
     for module in [
         "add",
+        "apply",
         "delete",
         "diff",
         "exceptions",


### PR DESCRIPTION
Resolves #40

`apply` uses special formats and notes that start with `ERROR`, `WARN`, or `INFO` to identify what is applied vs. what has been manually added by the user.

I made some updates to `format.tsv` and `note.tsv` as well because previously these used Sheet ID as the reference. If we try to apply formatting and notes to a sheet that does not yet have an ID (e.g. it has been added but not pushed), this will cause a problem.

My only concern is how this behavior will work if a sheet is renamed.

Another note - there is no link for the "standardized problems" yet. Maybe we should write something up for ROBOT?

---

### `apply`
<!-- TODO: ROBOT page describing error tables? -->
Running `apply` applies the details of [standardized problems]() from [ROBOT validate](http://robot.obolibrary.org/validate) or [ROBOT template](http://robot.obolibrary.org/template) to the spreadsheet as cell formatting and notes.

```
cogs apply [problems_table]
```

ROBOT has three levels of problems which will be formatted with a black border and the following backgrounds:
* **error**: light red background
* **warn/warning**: light yellow background
* **info**: light blue background

The notes and formats will be added to any existing, but will take priority over the existing notes and formats.

Running `apply` again will remove any "applied" formats and notes from the last time `apply` was run and add new details from the current problems table. To erase all "applied" formats and notes, run `cogs apply` with no additional arguments. Existing formats and notes added by the user will not be removed.
