### PR TITLE
Fix push with no notes, allow multiple apply sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ This does not add the table to the spreadsheet as a sheet - use `cogs push` to p
 
 ### `apply`
 
-Running `apply` applies the details of [standardized problems tables](#standardized-problems-tables) to the spreadsheet as cell formatting and notes.
+Running `apply` applies the details of one or more [standardized problems tables](#standardized-problems-tables) to the spreadsheet as cell formatting and notes.
 
 ```
-cogs apply [problems_table]
+cogs apply [problems1.tsv problems2.tsv ...]
 ```
 
 The three levels of problems will be formatted with a black border and the following backgrounds:
@@ -105,7 +105,7 @@ The three levels of problems will be formatted with a black border and the follo
 
 The notes and formats will be added to any existing, but will take priority over the existing notes and formats.
 
-Running `apply` again will remove any "applied" formats and notes from the last time `apply` was run and add new details from the current problems table. To erase all "applied" formats and notes, run `cogs apply` with no additional arguments. Existing formats and notes added by the user will not be removed.
+Running `apply` again will remove any "applied" formats and notes from the last time `apply` was run and add new details from the current problems table(s). To erase all "applied" formats and notes, run `cogs apply` with no additional arguments. Existing formats and notes added by the user will not be removed.
 
 #### Standardized Problems Tables
 

--- a/src/cogs/cli.py
+++ b/src/cogs/cli.py
@@ -28,7 +28,9 @@ def version(args):
 def main():
     parser = ArgumentParser()
     global_parser = ArgumentParser(add_help=False)
-    global_parser.add_argument("-v", "--verbose", help="Print logging", action="store_true")
+    global_parser.add_argument(
+        "-v", "--verbose", help="Print logging", action="store_true"
+    )
     subparsers = parser.add_subparsers(required=True, dest="cmd")
 
     sp = subparsers.add_parser("version", parents=[global_parser])
@@ -37,12 +39,19 @@ def main():
     # ------------------------------- add -------------------------------
     sp = subparsers.add_parser("add", parents=[global_parser])
     sp.add_argument("path", help="Path to TSV or CSV to add to COGS project")
-    sp.add_argument("-d", "--description", help="Description of sheet to add to spreadsheet")
+    sp.add_argument(
+        "-d", "--description", help="Description of sheet to add to spreadsheet"
+    )
     sp.set_defaults(func=add.run)
 
     # ------------------------------- apply -------------------------------
     sp = subparsers.add_parser("apply", parents=[global_parser])
-    sp.add_argument("problems_table", nargs="?", default=None, help="Path to ROBOT standardized problems table")
+    sp.add_argument(
+        "problems_tables",
+        nargs="*",
+        default=None,
+        help="Path(s) to ROBOT standardized problems table",
+    )
     sp.set_defaults(func=apply.run)
 
     # ------------------------------- delete -------------------------------
@@ -66,7 +75,10 @@ def main():
     sp.add_argument("-t", "--title", required=True, help="Title of the project")
     sp.add_argument("-u", "--user", help="Email (user) to share spreadsheet with")
     sp.add_argument(
-        "-r", "--role", default="writer", help="Role for specified user (default: owner)",
+        "-r",
+        "--role",
+        default="writer",
+        help="Role for specified user (default: owner)",
     )
     sp.add_argument("-U", "--users", help="TSV containing user emails and their roles")
     sp.set_defaults(func=init.run)
@@ -95,12 +107,16 @@ def main():
 
     # -------------------------------- rm --------------------------------
     sp = subparsers.add_parser("rm", parents=[global_parser])
-    sp.add_argument("paths", help="Path to TSV or CSV to remove from COGS project", nargs='+')
+    sp.add_argument(
+        "paths", help="Path to TSV or CSV to remove from COGS project", nargs="+"
+    )
     sp.set_defaults(func=rm.run)
 
     # ------------------------------- share -------------------------------
     sp = subparsers.add_parser("share", parents=[global_parser])
-    sp.add_argument("-o", "--owner", help="Email of user to transfer ownership of spreadsheet to")
+    sp.add_argument(
+        "-o", "--owner", help="Email of user to transfer ownership of spreadsheet to"
+    )
     sp.add_argument("-w", "--writer", help="Email of user to grant write access to")
     sp.add_argument("-r", "--reader", help="Email of user to grant read access to")
     sp.set_defaults(func=share.run)

--- a/src/cogs/push.py
+++ b/src/cogs/push.py
@@ -26,6 +26,8 @@ def add_notes(spreadsheet, sheet_notes, tracked_sheets):
                         "fields": "note",
                     }
                 })
+    if not requests:
+        return
     try:
         logging.info(f"adding {len(requests)} notes to spreadsheet")
         spreadsheet.batch_update({"requests": requests})


### PR DESCRIPTION
When running `cogs push` with no notes in `note.tsv`, COGS will print an error message (although it won't fail). This PR fixes that error.

This PR also includes support for multiple tables in `apply`:
```
cogs apply table-1.tsv table-2.tsv ...
```