### PR TITLE
Allow either path or env variable for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,15 @@ Running `init` creates a `.cogs` directory containing configuration data. This a
 cogs init -c [path-to-credentials] -t [project-title] -u [email] -r [role]
 ```
 
+`gspread` needs credentials to create a service account; you can either provide these with a file (`-c [path]`) or with an environment variable (`GOOGLE_CREDENTIALS`). The environment variable should be a string containing the contents of the credentials file. You must surround the contents with single quotes when setting this variable:
+
+```
+export GOOGLE_CREDENTIALS='{...}'
+```
+
 Options:
-- `-c`/`--credentials`: **required**, path to [Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format
 - `-t`/`--title`: **required**, title of the project which will be used as the title of the Google spreadsheet
+- `-c`/`--credentials`: path to [Google API credentials](https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project) in JSON format
 - `-u`/`--user`: email of the user to share the sheet with (if a `--role` is not specified, this user will be a writer)
 - `-r`/`--role`: role of the user specified by `--user`: `writer` or `reader`
 - `-U`/`--users`: path to TSV containing emails and roles for multiple users (header optional)

--- a/cogs/add.py
+++ b/cogs/add.py
@@ -3,12 +3,6 @@ import sys
 
 from cogs.helpers import *
 from cogs.exceptions import CogsError, AddError
-from cogs.helpers import (
-    get_fields,
-    get_tracked_sheets,
-    set_logging,
-    validate_cogs_project,
-)
 
 
 def msg():

--- a/cogs/apply.py
+++ b/cogs/apply.py
@@ -1,18 +1,6 @@
-import csv
-import logging
-import os
 import sys
 
-from cogs.exceptions import CogsError
-from cogs.helpers import (
-    get_sheet_formats,
-    get_sheet_notes,
-    get_tracked_sheets,
-    set_logging,
-    validate_cogs_project,
-    update_format,
-    update_note,
-)
+from cogs.helpers import *
 
 
 def msg():

--- a/cogs/cli.py
+++ b/cogs/cli.py
@@ -120,7 +120,7 @@ def main():
         usage="cogs init -c CREDENTIALS -t TITLE [-u USER [-r ROLE]] [-U USERS]",
     )
     sp.add_argument(
-        "-c", "--credentials", required=True, help="Path to service account credentials"
+        "-c", "--credentials", help="Path to service account credentials"
     )
     sp.add_argument("-t", "--title", required=True, help="Title of the project")
     sp.add_argument("-u", "--user", help="Email (user) to share spreadsheet with")

--- a/cogs/delete.py
+++ b/cogs/delete.py
@@ -1,11 +1,8 @@
-import gspread
-import logging
-import os
 import shutil
 import sys
 
-from cogs.exceptions import CogsError, DeleteError
-from cogs.helpers import get_client, get_config, set_logging, validate_cogs_project
+from cogs.exceptions import DeleteError
+from cogs.helpers import *
 
 
 def msg():
@@ -29,7 +26,7 @@ def delete(args):
             sys.exit(0)
 
     # Get a client to perform Sheet actions
-    gc = get_client(config["Credentials"])
+    gc = get_client_from_config(config)
 
     # Delete the Sheet
     title = config["Title"]

--- a/cogs/diff.py
+++ b/cogs/diff.py
@@ -1,11 +1,9 @@
 import curses
-import logging
-import os
 import sys
 import tabulate
 
-from cogs.exceptions import CogsError, DiffError
-from cogs.helpers import get_diff, get_tracked_sheets, set_logging, validate_cogs_project
+from cogs.exceptions import DiffError
+from cogs.helpers import *
 
 
 def msg():

--- a/cogs/fetch.py
+++ b/cogs/fetch.py
@@ -72,7 +72,7 @@ def fetch(args):
     # Get the remote sheets from spreadsheet
     sheets = spreadsheet.worksheets()
     remote_sheets = get_remote_sheets(sheets)
-    tracked_sheets = get_tracked_sheets()
+    tracked_sheets = get_tracked_sheets(include_no_id=False)
     id_to_title = {
         int(details["ID"]): sheet_title
         for sheet_title, details in tracked_sheets.items()

--- a/cogs/fetch.py
+++ b/cogs/fetch.py
@@ -62,9 +62,9 @@ def fetch(args):
     validate_cogs_project()
 
     config = get_config()
-    client = get_client(config["Credentials"])
+    gc = get_client_from_config(config)
     title = config["Title"]
-    spreadsheet = client.open(title)
+    spreadsheet = gc.open(title)
 
     # Get existing fields (headers) to see if we need to add/remove fields
     headers = []

--- a/cogs/fetch.py
+++ b/cogs/fetch.py
@@ -23,7 +23,11 @@ def get_cell_data(sheet):
     )
     cells = {}
     idx_y = 1
-    for row in resp["sheets"][0]["data"][0]["rowData"]:
+    data = resp["sheets"][0]["data"][0]
+    if "rowData" not in data:
+        # Empty sheet
+        return cells
+    for row in data["rowData"]:
         if not row:
             # Empty row
             continue

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -215,7 +215,7 @@ def get_renamed_sheets():
     return renamed
 
 
-def get_tracked_sheets():
+def get_tracked_sheets(include_no_id=True):
     """Get the current tracked sheets in this project from sheet.tsv as a dict of sheet title ->
     path & ID. They may or may not have corresponding cached/local sheets."""
     sheets = {}
@@ -224,6 +224,9 @@ def get_tracked_sheets():
         for row in reader:
             title = row["Title"]
             if not title:
+                continue
+            sheet_id = row["ID"]
+            if not include_no_id and sheet_id == "":
                 continue
             del row["Title"]
             sheets[title] = row

--- a/cogs/init.py
+++ b/cogs/init.py
@@ -1,12 +1,7 @@
-import csv
-import gspread
-import json
-import logging
-import os
 import sys
 
-from cogs.exceptions import CogsError, InitError
-from cogs.helpers import get_client, is_email, is_valid_role, get_version, set_logging
+from cogs.exceptions import InitError
+from cogs.helpers import *
 
 
 default_fields = [
@@ -208,7 +203,8 @@ def write_data(args, sheet):
         v = get_version()
         writer.writerow({"Key": "COGS", "Value": "https://github.com/ontodev/cogs"})
         writer.writerow({"Key": "COGS Version", "Value": v})
-        writer.writerow({"Key": "Credentials", "Value": args.credentials})
+        if args.credentials:
+            writer.writerow({"Key": "Credentials", "Value": args.credentials})
         writer.writerow({"Key": "Title", "Value": args.title})
         writer.writerow({"Key": "Spreadsheet ID", "Value": sheet.id})
 
@@ -281,7 +277,12 @@ def init(args):
     users = get_users(args)
 
     # Create a Client to access API
-    gc = get_client(args.credentials)
+    if args.credentials:
+        # Use a credentials file
+        gc = get_client(credentials_path=args.credentials)
+    else:
+        # Use environment vars
+        gc = get_client()
 
     # Create the new Sheet
     try:

--- a/cogs/mv.py
+++ b/cogs/mv.py
@@ -1,12 +1,9 @@
-import csv
-import logging
 import ntpath
-import os
 import shutil
 import sys
 
-from cogs.exceptions import CogsError, MvError
-from cogs.helpers import get_tracked_sheets, set_logging, validate_cogs_project
+from cogs.exceptions import MvError
+from cogs.helpers import *
 
 
 def msg():

--- a/cogs/open.py
+++ b/cogs/open.py
@@ -1,8 +1,6 @@
-import logging
 import sys
 
-from cogs.exceptions import CogsError
-from cogs.helpers import get_config, set_logging, validate_cogs_project
+from cogs.helpers import *
 
 
 def msg():

--- a/cogs/pull.py
+++ b/cogs/pull.py
@@ -1,10 +1,7 @@
-import logging
-import os
 import shutil
 import sys
 
-from cogs.exceptions import CogsError
-from cogs.helpers import get_cached_sheets, get_tracked_sheets, set_logging, validate_cogs_project
+from cogs.helpers import *
 
 
 def msg():

--- a/cogs/push.py
+++ b/cogs/push.py
@@ -50,7 +50,7 @@ def push(args):
     set_logging(args.verbose)
     validate_cogs_project()
     config = get_config()
-    gc = get_client(config["Credentials"])
+    gc = get_client_from_config(config)
     spreadsheet = gc.open(config["Title"])
 
     # Get tracked sheets

--- a/cogs/share.py
+++ b/cogs/share.py
@@ -1,9 +1,6 @@
-import gspread
-import logging
 import sys
 
-from cogs.exceptions import CogsError
-from cogs.helpers import get_client, get_config, set_logging, validate_cogs_project
+from cogs.helpers import *
 
 
 def msg():
@@ -25,7 +22,7 @@ def share(args):
     validate_cogs_project()
 
     config = get_config()
-    gc = get_client(config["Credentials"])
+    gc = get_client_from_config(config)
 
     title = config["Title"]
     spreadsheet = gc.open(title)

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -1,17 +1,7 @@
-import logging
-import os
 import sys
 import termcolor
 
-from cogs.exceptions import CogsError
-from cogs.helpers import (
-    get_cached_sheets,
-    get_diff,
-    get_renamed_sheets,
-    get_tracked_sheets,
-    set_logging,
-    validate_cogs_project,
-)
+from cogs.helpers import *
 
 
 def msg():


### PR DESCRIPTION
### `init`

Running `init` creates a `.cogs` directory containing configuration data. This also creates a new Google Sheets spreadsheet and stores the ID. Optionally, this new sheet may be shared with users.

```
cogs init -c [path-to-credentials] -t [project-title] -u [email] -r [role]
```

`gspread` needs credentials to create a service account; you can either provide these with a file (`-c [path]`) or with an environment variable (`GOOGLE_CREDENTIALS`). The environment variable should be a string containing the contents of the credentials file. You must surround the contents with single quotes when setting this variable:

```
export GOOGLE_CREDENTIALS='{...}'
```