### PR TITLE
Add option to freeze rows or columns with add

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,13 @@ Running `add` will begin tracking a local TSV or CSV table. The table details (p
 cogs add [path] -d "[description]"
 ```
 
-The `-d`/`--description` is optional.
+The `-d`/`--description` is optional. You can also specify a number of rows and or columns to freeze:
+
+```
+cogs add [path] -r [freeze_row] -c [freeze_column]
+```
+
+If you specify `-r 2 -c 1`, then the first two rows and the first column will be frozen once the sheet is pushed to the remote Google Spreadsheet. If these options are not included, no rows or columns will be frozen.
 
 The sheet title is created from the path (e.g., `tables/foo.tsv` will be named `foo`). If a sheet with this title already exists in the project, the task will fail. The sheet/file name cannot be one of the COGS reserved names: `config`, `field`, `sheet`, `renamed`, or `user`.
 

--- a/cogs/add.py
+++ b/cogs/add.py
@@ -88,8 +88,8 @@ def add(args):
                 "Title": title,
                 "Path": args.path,
                 "Description": description,
-                "Frozen Rows": 0,
-                "Frozen Columns": 0,
+                "Frozen Rows": args.freeze_row,
+                "Frozen Columns": args.freeze_column,
             }
         )
 

--- a/cogs/cli.py
+++ b/cogs/cli.py
@@ -61,7 +61,7 @@ def main():
         "add",
         parents=[global_parser],
         description=add.msg(),
-        usage="cogs add PATH [-d DESCRIPTION]",
+        usage="cogs add PATH [-d DESCRIPTION -r FREEZE_ROW -c FREEZE_COLUMN]",
     )
     sp.add_argument("path", help="Path to TSV or CSV to add to COGS project")
     sp.add_argument(

--- a/cogs/cli.py
+++ b/cogs/cli.py
@@ -67,6 +67,12 @@ def main():
     sp.add_argument(
         "-d", "--description", help="Description of sheet to add to spreadsheet"
     )
+    sp.add_argument(
+        "-r", "--freeze-row", help="Row number to freeze up to", default="0"
+    )
+    sp.add_argument(
+        "-c", "--freeze-column", help="Column number to freeze up to", default="0"
+    )
     sp.set_defaults(func=add.run)
 
     # ------------------------------- apply -------------------------------
@@ -119,9 +125,7 @@ def main():
         description=init.msg(),
         usage="cogs init -c CREDENTIALS -t TITLE [-u USER [-r ROLE]] [-U USERS]",
     )
-    sp.add_argument(
-        "-c", "--credentials", help="Path to service account credentials"
-    )
+    sp.add_argument("-c", "--credentials", help="Path to service account credentials")
     sp.add_argument("-t", "--title", required=True, help="Title of the project")
     sp.add_argument("-u", "--user", help="Email (user) to share spreadsheet with")
     sp.add_argument(

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -46,7 +46,12 @@ def get_client(credentials_path=None):
         credentials = json.loads(env["GOOGLE_CREDENTIALS"])
     else:
         # Otherwise load from credentials path
-        credentials = json.load(open(credentials_path))
+        try:
+            credentials = json.load(open(credentials_path))
+        except FileNotFoundError:
+            raise CogsError(
+                f"Unable to create a Client; credentials file at {credentials_path} does not exist"
+            )
 
     try:
         # Create Credentials object and add scope (spreadsheets & drive)


### PR DESCRIPTION
Resolves #49

---

You can also specify a number of rows and or columns to freeze:

```
cogs add [path] -r [freeze_row] -c [freeze_column]
```

If you specify `-r 2 -c 1`, then the first two rows and the first column will be frozen once the sheet is pushed to the remote Google Spreadsheet. If these options are not included, no rows or columns will be frozen.