### PR TITLE
Add `--title` option to `add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cogs add [path] -r [freeze_row] -c [freeze_column]
 
 If you specify `-r 2 -c 1`, then the first two rows and the first column will be frozen once the sheet is pushed to the remote Google Spreadsheet. If these options are not included, no rows or columns will be frozen.
 
-By default, he sheet title is created from the path (e.g., `tables/foo.tsv` will be named `foo`). If a sheet with this title already exists in the project, the task will fail. The sheet/file name cannot be one of the COGS reserved names: `config`, `field`, `sheet`, `renamed`, or `user`.
+By default, the sheet title is created from the path (e.g. `tables/foo.tsv` will be named `foo`). If a sheet with this title already exists in the project, the task will fail. The sheet title cannot be one of the COGS reserved names: `config`, `field`, `sheet`, `renamed`, or `user`.
 
 You can also specify a sheet title that is different from the path with the `-t`/`--title` option:
 
@@ -117,7 +117,7 @@ You can also specify a sheet title that is different from the path with the `-t`
 cogs add [path] -t "[title]"
 ```
 
-This does not add the table to the spreadsheet as a sheet - use `cogs push` to push all tracked local tables to the project spreadsheet.
+This does not immediately change the Google Sheet -- use `cogs push` to push all tracked local tables to the project spreadsheet.
 
 ### `apply`
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,13 @@ cogs add [path] -r [freeze_row] -c [freeze_column]
 
 If you specify `-r 2 -c 1`, then the first two rows and the first column will be frozen once the sheet is pushed to the remote Google Spreadsheet. If these options are not included, no rows or columns will be frozen.
 
-The sheet title is created from the path (e.g., `tables/foo.tsv` will be named `foo`). If a sheet with this title already exists in the project, the task will fail. The sheet/file name cannot be one of the COGS reserved names: `config`, `field`, `sheet`, `renamed`, or `user`.
+By default, he sheet title is created from the path (e.g., `tables/foo.tsv` will be named `foo`). If a sheet with this title already exists in the project, the task will fail. The sheet/file name cannot be one of the COGS reserved names: `config`, `field`, `sheet`, `renamed`, or `user`.
+
+You can also specify a sheet title that is different from the path with the `-t`/`--title` option:
+
+```
+cogs add [path] -t "[title]"
+```
 
 This does not add the table to the spreadsheet as a sheet - use `cogs push` to push all tracked local tables to the project spreadsheet.
 

--- a/cogs/add.py
+++ b/cogs/add.py
@@ -9,41 +9,8 @@ def msg():
     return "Add a table (TSV or CSV) to the project"
 
 
-def add(args):
-    """Add a table (TSV or CSV) to the COGS project. This updates sheet.tsv and field.tsv."""
-    set_logging(args.verbose)
-    validate_cogs_project()
-
-    # Open the provided file and make sure we can parse it as TSV or CSV
-    if args.path.endswith(".csv"):
-        delimiter = ","
-        fmt = "CSV"
-    else:
-        delimiter = "\t"
-        fmt = "TSV"
-    with open(args.path, "r") as f:
-        try:
-            reader = csv.DictReader(f, delimiter=delimiter)
-        except csv.Error as e:
-            raise AddError(f"unable to read {args.path} as {fmt}\nCAUSE:{str(e)}")
-        headers = reader.fieldnames
-
-    # Create the sheet title from file basename
-    title = ntpath.basename(args.path).split(".")[0]
-    if title in reserved_names:
-        raise AddError(f"sheet cannot use reserved name '{title}'")
-
-    # Make sure we aren't duplicating a table
-    local_sheets = get_tracked_sheets()
-    if title in local_sheets:
-        raise AddError(f"'{title}' sheet already exists in this project")
-
-    # Maybe get a description
-    description = ""
-    if args.description:
-        description = args.description
-
-    # Get the headers to add to field.tsv if they do not exist
+def maybe_update_fields(headers):
+    """Check fieldnames in headers and add to field.tsv if they do not exist."""
     fields = get_fields()
     update_fields = False
     for h in headers:
@@ -66,6 +33,55 @@ def add(args):
                 items["Field"] = field
                 writer.writerow(items)
 
+
+def add(args):
+    """Add a table (TSV or CSV) to the COGS project. This updates sheet.tsv and field.tsv."""
+    set_logging(args.verbose)
+    validate_cogs_project()
+
+    # Open the provided file and make sure we can parse it as TSV or CSV
+    path = args.path
+    if path.endswith(".csv"):
+        delimiter = ","
+        fmt = "CSV"
+    else:
+        delimiter = "\t"
+        fmt = "TSV"
+    with open(path, "r") as f:
+        try:
+            reader = csv.DictReader(f, delimiter=delimiter)
+        except csv.Error as e:
+            raise AddError(f"unable to read {path} as {fmt}\nCAUSE:{str(e)}")
+        headers = reader.fieldnames
+
+    if args.title:
+        # Get the title from args
+        title = args.title
+    else:
+        # Create the sheet title from file basename
+        title = ntpath.basename(path).split(".")[0]
+    if title in reserved_names:
+        raise AddError(f"sheet cannot use reserved name '{title}'")
+
+    # Make sure we aren't duplicating a table
+    local_sheets = get_tracked_sheets()
+    if title in local_sheets:
+        raise AddError(f"'{title}' sheet already exists in this project")
+
+    # Make sure we aren't duplicating a path
+    local_paths = {x["Path"]: t for t, x in local_sheets.items()}
+    if path in local_paths.keys():
+        other_title = local_paths[path]
+        raise AddError(f"Local table {path} already exists as '{other_title}'")
+
+    # Maybe get a description
+    description = ""
+    if args.description:
+        description = args.description
+
+    if headers:
+        maybe_update_fields(headers)
+
     # Finally, add this TSV to sheet.tsv
     with open(".cogs/sheet.tsv", "a") as f:
         writer = csv.DictWriter(
@@ -86,7 +102,7 @@ def add(args):
             {
                 "ID": "",
                 "Title": title,
-                "Path": args.path,
+                "Path": path,
                 "Description": description,
                 "Frozen Rows": args.freeze_row,
                 "Frozen Columns": args.freeze_column,

--- a/cogs/cli.py
+++ b/cogs/cli.py
@@ -61,9 +61,10 @@ def main():
         "add",
         parents=[global_parser],
         description=add.msg(),
-        usage="cogs add PATH [-d DESCRIPTION -r FREEZE_ROW -c FREEZE_COLUMN]",
+        usage="cogs add PATH [-t TITLE -d DESCRIPTION -r FREEZE_ROW -c FREEZE_COLUMN]",
     )
     sp.add_argument("path", help="Path to TSV or CSV to add to COGS project")
+    sp.add_argument("-t", "--title", help="Title of the sheet")
     sp.add_argument(
         "-d", "--description", help="Description of sheet to add to spreadsheet"
     )

--- a/cogs/push.py
+++ b/cogs/push.py
@@ -113,14 +113,19 @@ def push(args):
             continue
         with open(sheet_path, "r") as f:
             reader = csv.reader(f, delimiter=delimiter)
-            header = next(reader)
-            rows.append(header)
-            headers.extend(header)
-            for row in reader:
-                row_len = len(row)
-                if row_len > cols:
-                    cols = row_len
-                rows.append(row)
+            try:
+                header = next(reader)
+            except StopIteration:
+                # No contents in file
+                header = None
+            if header:
+                rows.append(header)
+                headers.extend(header)
+                for row in reader:
+                    row_len = len(row)
+                    if row_len > cols:
+                        cols = row_len
+                    rows.append(row)
 
         # Set sheet size
         if len(rows) < 500:


### PR DESCRIPTION
Resolves #59 
Also fixes an issue adding/pushing an empty sheet.

From the docs:

You can also specify a sheet title that is different from the path with the `-t`/`--title` option:

```
cogs add [path] -t "[title]"
```
