### PR TITLE
Move all sheet data to .cogs/tracked directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ cogs add [path] -r [freeze_row] -c [freeze_column]
 
 If you specify `-r 2 -c 1`, then the first two rows and the first column will be frozen once the sheet is pushed to the remote Google Spreadsheet. If these options are not included, no rows or columns will be frozen.
 
-By default, the sheet title is created from the path (e.g. `tables/foo.tsv` will be named `foo`). If a sheet with this title already exists in the project, the task will fail. The sheet title cannot be one of the COGS reserved names: `config`, `field`, `sheet`, `renamed`, or `user`.
+By default, the sheet title is created from the path (e.g. `tables/foo.tsv` will be named `foo`). If a sheet with this title already exists in the project, the task will fail.
 
 You can also specify a sheet title that is different from the path with the `-t`/`--title` option:
 
@@ -236,7 +236,7 @@ Running `fetch` will sync the local `.cogs/` directory with all remote spreadshe
 cogs fetch
 ```
 
-This will download all sheets in the spreadsheet to that directory as `{sheet-title}.tsv` - this will overwrite the existing sheets in `.cogs/`, but will not overwrite the local versions specified by their path. As the sheets are downloaded, the fields are checked against existing fields in `.cogs/field.tsv` and any new fields are added with the default datatype of `cogs:text` (text string). Any sheets that have been added with `add` and then pushed to the remote sheet with `push` will be given their IDs in `.cogs/sheet.tsv`.
+This will download all sheets in the spreadsheet to that directory as `{sheet-title}.tsv` - this will overwrite the existing sheets in `.cogs/tracked/`, but will not overwrite the local versions specified by their path. As the sheets are downloaded, the fields are checked against existing fields in `.cogs/field.tsv` and any new fields are added with the default datatype of `cogs:text` (text string). Any sheets that have been added with `add` and then pushed to the remote sheet with `push` will be given their IDs in `.cogs/sheet.tsv`.
 
 `.cogs/format.tsv` and `.cogs/note.tsv` are also updated for any cell formatting or notes on cells, respectively. Each unique format is given a numerical ID and is stored as [CellFormat JSON](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/cells#cellformat).
 

--- a/cogs/add.py
+++ b/cogs/add.py
@@ -60,8 +60,6 @@ def add(args):
     else:
         # Create the sheet title from file basename
         title = ntpath.basename(path).split(".")[0]
-    if title in reserved_names:
-        raise AddError(f"sheet cannot use reserved name '{title}'")
 
     # Make sure we aren't duplicating a table
     local_sheets = get_tracked_sheets()

--- a/cogs/diff.py
+++ b/cogs/diff.py
@@ -23,7 +23,7 @@ def get_lines(sheets):
     """Return the lines for a diff as an array of pairs (text, formatting)."""
     lines = []
     for sheet_title, details in sheets.items():
-        remote = f".cogs/{sheet_title}.tsv"
+        remote = f".cogs/tracked/{sheet_title}.tsv"
         local = details["Path"]
         if os.path.exists(local) and os.path.exists(remote):
             sheet_diff = get_diff(local, remote)

--- a/cogs/fetch.py
+++ b/cogs/fetch.py
@@ -2,7 +2,6 @@ import datetime
 import gspread.utils
 import sys
 
-from cogs.exceptions import FetchError
 from cogs.helpers import *
 
 
@@ -50,10 +49,6 @@ def get_remote_sheets(sheets):
     # Validate sheet titles before downloading anything
     remote_sheets = {}
     for sheet in sheets:
-        if sheet.title in ["user", "config", "sheet", "field", "renamed"]:
-            raise FetchError(
-                f"cannot export remote sheet with the reserved name '{sheet.title}'"
-            )
         remote_sheets[sheet.title] = sheet.id
     return remote_sheets
 
@@ -206,10 +201,6 @@ def fetch(args):
                     )
                     renamed_remote[local_title] = {"new": st, "path": st + ".tsv"}
             logging.info(f"Downloading remote sheet '{st}'")
-
-        if st in reserved_names:
-            # Remote sheet has reserved sheet name - exit
-            raise FetchError(f"sheet cannot use reserved name '{st}'")
 
         # Get frozen rows & columns
         sheet_frozen[st] = {

--- a/cogs/fetch.py
+++ b/cogs/fetch.py
@@ -58,6 +58,84 @@ def get_remote_sheets(sheets):
     return remote_sheets
 
 
+def get_updated_sheet_details(tracked_sheets, remote_sheets, sheet_frozen):
+    """Format details from the various dicts to create rows for sheet.tsv."""
+    all_sheets = []
+    for sheet_title, details in tracked_sheets.items():
+        if sheet_title in remote_sheets:
+            sid = remote_sheets[sheet_title]
+            details["ID"] = sid
+            if sheet_title in sheet_frozen:
+                frozen = sheet_frozen[sheet_title]
+                details["Frozen Rows"] = frozen["row"]
+                details["Frozen Columns"] = frozen["col"]
+            else:
+                details["Frozen Rows"] = 0
+                details["Frozen Columns"] = 0
+        details["Title"] = sheet_title
+        all_sheets.append(details)
+    return all_sheets
+
+
+def remove_sheets(sheets, tracked_sheets, renamed_local):
+    """Remove tracked sheets that are no longer in the remote spreadsheet.
+    Return the titles of these sheets."""
+    # Get all cached sheet titles
+    cached_sheet_titles = get_cached_sheets()
+    new_local_titles = [details["new"] for details in renamed_local.values()]
+    remote_titles = [x.title for x in sheets]
+    removed_titles = []
+    for sheet_title in cached_sheet_titles:
+        if sheet_title not in remote_titles and sheet_title not in new_local_titles:
+            # This sheet has a cached copy but does not exist in the remote version
+            # It has either been removed from remote or was newly added to cache
+            if (
+                    sheet_title in tracked_sheets
+                    and tracked_sheets[sheet_title]["ID"].strip != ""
+            ) or (sheet_title not in tracked_sheets):
+                # The sheet is in tracked sheets and has an ID (not newly added)
+                # or the sheet is not in tracked sheets
+                removed_titles.append(sheet_title)
+                logging.info(f"Removing '{sheet_title}'")
+                os.remove(f".cogs/tracked/{sheet_title}.tsv")
+    return removed_titles
+
+
+def get_sheet_details(sheet_title, sid, sheet_frozen, tracked_sheets):
+    """Get the sheet details formatted for sheet.tsv."""
+    sheet_paths = {
+        details["Path"]: loc_sheet_title
+        for loc_sheet_title, details in tracked_sheets.items()
+    }
+    if sheet_title in sheet_frozen:
+        frozen = sheet_frozen[sheet_title]
+        frozen_row = frozen["row"]
+        frozen_col = frozen["col"]
+    else:
+        frozen_row = 0
+        frozen_col = 0
+    sheet_path = re.sub(r"[^A-Za-z0-9]+", "_", sheet_title.lower()).strip("_")
+    # Make sure the path is unique - the user can change this later
+    if sheet_path + ".tsv" in sheet_paths.keys():
+        # Append datetime if this path already exists
+        td = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        sheet_path += f"_{td}.tsv"
+    else:
+        sheet_path += ".tsv"
+    logging.info(
+        f"new sheet '{sheet_title}' added to project with local path {sheet_path}"
+    )
+    details = {
+        "ID": sid,
+        "Title": sheet_title,
+        "Path": sheet_path,
+        "Description": "",
+        "Frozen Rows": frozen_row,
+        "Frozen Columns": frozen_col,
+    }
+    return details
+
+
 def fetch(args):
     """Fetch all sheets from project spreadsheet to .cogs/ directory."""
     set_logging(args.verbose)
@@ -82,7 +160,6 @@ def fetch(args):
 
     # Get details about renamed sheets
     renamed_local = get_renamed_sheets()
-    new_local_titles = [details["new"] for details in renamed_local.values()]
     renamed_remote = {}
 
     # Format ID to format for cell formatting
@@ -220,8 +297,8 @@ def fetch(args):
         if cell_to_note:
             sheet_notes[st] = cell_to_note
 
-        # Write values to .cogs/{sheet title}.tsv
-        with open(f".cogs/{st}.tsv", "w") as f:
+        # Write values to .cogs/tracked/{sheet title}.tsv
+        with open(f".cogs/tracked/{st}.tsv", "w") as f:
             lines = sheet.get_all_values()
             writer = csv.writer(f, delimiter="\t", lineterminator="\n")
             writer.writerows(lines)
@@ -235,51 +312,17 @@ def fetch(args):
     with open(".cogs/formats.json", "w") as f:
         f.write(json.dumps(id_to_format, sort_keys=True, indent=4))
 
-    # Update local sheets with new IDs
-    all_sheets = []
-    for sheet_title, details in tracked_sheets.items():
-        if sheet_title in remote_sheets:
-            sid = remote_sheets[sheet_title]
-            details["ID"] = sid
-            if sheet_title in sheet_frozen:
-                frozen = sheet_frozen[sheet_title]
-                details["Frozen Rows"] = frozen["row"]
-                details["Frozen Columns"] = frozen["col"]
-            else:
-                details["Frozen Rows"] = 0
-                details["Frozen Columns"] = 0
-        details["Title"] = sheet_title
-        all_sheets.append(details)
-
-    # Get all cached sheet titles that are not COGS defaults
-    cached_sheet_titles = get_cached_sheets()
+    # Update local sheets details in sheet.tsv with new IDs & details for current tracked sheets
+    all_sheets = get_updated_sheet_details(tracked_sheets, remote_sheets, sheet_frozen)
 
     # If a cached sheet title is not in sheet.tsv & not in remote sheets - remove it
-    remote_titles = [x.title for x in sheets]
-    removed_titles = []
-    for sheet_title in cached_sheet_titles:
-        if sheet_title not in remote_titles and sheet_title not in new_local_titles:
-            # This sheet has a cached copy but does not exist in the remote version
-            # It has either been removed from remote or was newly added to cache
-            if (
-                sheet_title in tracked_sheets
-                and tracked_sheets[sheet_title]["ID"].strip != ""
-            ) or (sheet_title not in tracked_sheets):
-                # The sheet is in tracked sheets and has an ID (not newly added)
-                # or the sheet is not in tracked sheets
-                removed_titles.append(sheet_title)
-                logging.info(f"Removing '{sheet_title}'")
-                os.remove(f".cogs/{sheet_title}.tsv")
+    removed_titles = remove_sheets(sheets, tracked_sheets, renamed_local)
 
     # Rewrite format.tsv and note.tsv with current remote formats & notes
     update_format(sheet_formats, removed_titles)
     update_note(sheet_notes, removed_titles)
 
     # Get just the remote sheets that are not in local sheets
-    sheet_paths = {
-        details["Path"]: loc_sheet_title
-        for loc_sheet_title, details in tracked_sheets.items()
-    }
     new_sheets = {
         sheet_title: sid
         for sheet_title, sid in remote_sheets.items()
@@ -287,32 +330,7 @@ def fetch(args):
     }
     for sheet_title, sid in new_sheets.items():
         if sheet_title not in renamed_local:
-            if sheet_title in sheet_frozen:
-                frozen = sheet_frozen[sheet_title]
-                frozen_row = frozen["row"]
-                frozen_col = frozen["col"]
-            else:
-                frozen_row = 0
-                frozen_col = 0
-            sheet_path = re.sub(r"[^A-Za-z0-9]+", "_", sheet_title.lower()).strip("_")
-            # Make sure the path is unique - the user can change this later
-            if sheet_path + ".tsv" in sheet_paths.keys():
-                # Append datetime if this path already exists
-                td = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-                sheet_path += f"_{td}.tsv"
-            else:
-                sheet_path += ".tsv"
-            logging.info(
-                f"new sheet '{sheet_title}' added to project with local path {sheet_path}"
-            )
-            details = {
-                "ID": sid,
-                "Title": sheet_title,
-                "Path": sheet_path,
-                "Description": "",
-                "Frozen Rows": frozen_row,
-                "Frozen Columns": frozen_col,
-            }
+            details = get_sheet_details(sheet_title, sid, sheet_frozen, tracked_sheets)
             all_sheets.append(details)
 
     # Then update sheet.tsv

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -11,8 +11,13 @@ from cogs.exceptions import CogsError
 from daff import Coopy, CompareFlags, PythonTableView, TableDiff
 from google.oauth2.service_account import Credentials
 
-reserved_names = ["format", "user", "config", "sheet", "field", "note", "renamed"]
-required_files = ["config.tsv", "field.tsv", "format.tsv", "note.tsv", "sheet.tsv"]
+required_files = [
+    "config.tsv",
+    "field.tsv",
+    "format.tsv",
+    "note.tsv",
+    "sheet.tsv",
+]
 optional_files = ["user.tsv", "renamed.tsv"]
 
 required_keys = ["Spreadsheet ID", "Title"]
@@ -21,16 +26,10 @@ credential_keys = []
 
 
 def get_cached_sheets():
-    """Return a list of names of cached sheets from .cogs. These are any sheets that have been
-    downloaded from the remote spreadsheet into the .cogs directory as TSVs. They may or may not be
-    tracked in sheet.tsv."""
-    cached = []
-    for f in os.listdir(".cogs"):
-        if not f.endswith("tsv"):
-            continue
-        if f not in required_files and f not in optional_files:
-            cached.append(f.split(".")[0])
-    return cached
+    """Return a list of names of cached sheets from .cogs/tracked. These are any sheets that have
+    been downloaded from the remote spreadsheet into the .cogs directory as TSVs. They may or may
+    not be tracked in sheet.tsv."""
+    return [f.split(".")[0] for f in os.listdir(".cogs/tracked")]
 
 
 def get_credentials(credentials_path=None):
@@ -111,7 +110,7 @@ def get_config():
 
 def get_diff(local, remote):
     """Return the diff between a local and remote sheet as a list of lines with formatting. The
-       remote table is the 'old' version and the local table is the 'new' version."""
+    remote table is the 'old' version and the local table is the 'new' version."""
     local_data = []
     with open(local, "r") as f:
         # Local might be CSV or TSV

--- a/cogs/init.py
+++ b/cogs/init.py
@@ -195,6 +195,9 @@ def get_users(args):
 
 def write_data(args, sheet):
     """Create COGS data files: config.tsv, sheet.tsv, and field.tsv."""
+    # Create the "tracked" directory
+    os.mkdir(".cogs/tracked")
+
     # Store COGS configuration
     with open(".cogs/config.tsv", "w") as f:
         writer = csv.DictWriter(

--- a/cogs/mv.py
+++ b/cogs/mv.py
@@ -51,7 +51,7 @@ def mv(args):
     selected_sheet = path_to_sheet[cur_path]
     new_sheet_title = ntpath.basename(args.new_path).split(".")[0]
     if selected_sheet != new_sheet_title:
-        if os.path.exists(f".cogs/{new_sheet_title}.tsv"):
+        if os.path.exists(f".cogs/tracked/{new_sheet_title}.tsv"):
             # A cached sheet with this name already exists
             existing_path = tracked_sheets[new_sheet_title]["Path"]
             raise MvError(
@@ -59,7 +59,10 @@ def mv(args):
                 f"a tracked sheet with this title already exists ({existing_path})"
             )
         logging.info(f"Renaming '{selected_sheet}' to '{new_sheet_title}'")
-        shutil.copyfile(f".cogs/{selected_sheet}.tsv", f".cogs/{new_sheet_title}.tsv")
+        shutil.copyfile(
+            f".cogs/tracked/{selected_sheet}.tsv",
+            f".cogs/tracked/{new_sheet_title}.tsv",
+        )
         with open(".cogs/renamed.tsv", "a") as f:
             f.write(f"{selected_sheet}\t{new_sheet_title}\t{args.new_path}\n")
 

--- a/cogs/pull.py
+++ b/cogs/pull.py
@@ -17,14 +17,14 @@ def pull(args):
     tracked_sheets = get_tracked_sheets()
     remove_sheets = [s for s in cached_sheets if s not in tracked_sheets.keys()]
     for sheet_title, details in tracked_sheets.items():
-        cached_sheet = f".cogs/{sheet_title}.tsv"
+        cached_sheet = f".cogs/tracked/{sheet_title}.tsv"
         local_sheet = details["Path"]
         if os.path.exists(cached_sheet):
             logging.info(f"Writing '{sheet_title}' to {local_sheet}")
             shutil.copyfile(cached_sheet, local_sheet)
     for sheet_title in remove_sheets:
         logging.info(f"Removing '{sheet_title}' from cached sheets")
-        os.remove(f".cogs/{sheet_title}.tsv")
+        os.remove(f".cogs/tracked/{sheet_title}.tsv")
 
 
 def run(args):

--- a/cogs/rm.py
+++ b/cogs/rm.py
@@ -62,11 +62,11 @@ def rm(args):
 
     for title, sheet in sheets.items():
         if (
-            not os.path.exists(f".cogs/{title}.tsv")
-            or os.stat(f".cogs/{title}.tsv").st_size == 0
+            not os.path.exists(f".cogs/tracked/{title}.tsv")
+            or os.stat(f".cogs/tracked/{title}.tsv").st_size == 0
         ):
             continue
-        with open(f".cogs/{title}.tsv", "r") as sheet_file:
+        with open(f".cogs/tracked/{title}.tsv", "r") as sheet_file:
             try:
                 reader = csv.DictReader(sheet_file, delimiter="\t")
             except csv.Error as e:

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -75,7 +75,7 @@ def get_changes(tracked_sheets, renamed):
             if sheet_title in renamed:
                 sheet_title = renamed[sheet_title]["new"]
             local_path = tracked_sheets[sheet_title]["Path"]
-            remote_path = f".cogs/{sheet_title}.tsv"
+            remote_path = f".cogs/tracked/{sheet_title}.tsv"
 
             # Check which version is newer based on file modification
             local_mod = os.path.getmtime(local_path)


### PR DESCRIPTION
Resolves #63 

I also tried to make the `fetch` and `push` methods a bit less complex by moving stuff around. There are still some methods that are considered "too complex" by `flake8`, but I'll probably do a different PR to start cleaning that sort of thing up.

Let's merge #58 before doing this because there might be some conflicts.