### PR TITLE
Allow escaping in comma-separated lists in validation.tsv

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Dates can be supplied in whatever format you like, but we recomment `YYYY-MM-DD`
 
 * *One-of Conditions*
 
-`ONE_OF_LIST` values should be supplied as a comma separated list. There should be at least two values in the list. For single values, use `TEXT_EQ` instead.
+`ONE_OF_LIST` values should be supplied as a comma separated list. There should be at least two values in the list. For single values, use `TEXT_EQ` instead. If an item in your `ONE_OF_LIST` contains a comma, escape it with a backslash (e.g., `single value 1, multi-value 2\, 3` will resolve to two values in the list).
 
 | Condition      | Values |
 | -------------- | ------ |

--- a/cogs/push.py
+++ b/cogs/push.py
@@ -112,9 +112,12 @@ def push_data_validation(spreadsheet, data_validation):
             condition = dv_rule["Condition"]
             value_str = dv_rule["Value"]
             if value_str != "":
-                value = value_str.split(", ")
+                # Split on non-escaped commas
+                value = re.compile(r"(?<!\\), ").split(value_str)
             else:
                 value = []
+            # Remove escape character
+            value = [re.sub(r"\\([^\\])", r"\1", x) for x in value]
             show_ui = False
             if condition.endswith("LIST"):
                 show_ui = True


### PR DESCRIPTION
Add support for escaping commas in the comma-separated lists for data validation values.

This allows you to add a value to a `ONE_OF_LIST` that contains a comma as long as you escape the comma (`\,`).