### PR TITLE
Fix operator in `apply`

### DIFF
--- a/cogs/apply.py
+++ b/cogs/apply.py
@@ -159,7 +159,7 @@ def apply_standardized_problems(problems_tables):
                 if current_fmt != 0:
                     cell_to_formats[cell] = 1
             elif level == "info":
-                if current_fmt > 1:
+                if current_fmt < 1:
                     cell_to_formats[cell] = 2
 
             instructions = None


### PR DESCRIPTION
Operator for info message was a greater-than symbol when it should be a less-than symbol. This caused INFO messages to only be a note with no blue background.