### PR TITLE
Add helpers.get_sheet_url() to init

### DIFF
--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -14,6 +14,7 @@ from cogs.push import push
 from cogs.rm import rm
 from cogs.share import share
 from cogs.status import status
+from cogs.helpers import get_sheet_url
 
 # Version of COGS
 __version__ = "0.0.1"


### PR DESCRIPTION
Allows ability to call `cogs.get_sheet_url()` instead of `cogs.helpers.get_sheet_url()`