### PR TITLE
Fail on adding table with empty first row

### DIFF
--- a/cogs/add.py
+++ b/cogs/add.py
@@ -50,6 +50,8 @@ def add(path, title=None, description=None, freeze_row=0, freeze_column=0, verbo
         except csv.Error as e:
             raise AddError(f"unable to read {path} as {fmt}\nCAUSE:{str(e)}")
         headers = reader.fieldnames
+        if not headers:
+            raise AddError(f"First row of {path} must contain headers")
 
     if not title:
         # Create the sheet title from file basename


### PR DESCRIPTION
Resolves #81

Note that this will also fail if the file is completely empty. Do we want to allow adding completely empty files, but not allow it if the file has contents without having headers on the first row?