### PR TITLE
Remove field.tsv from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Otherwise, most commands succeed silently.
 
 ### `add`
 
-Running `add` will begin tracking a local TSV or CSV table. The table details (path, name/title, and description) get added to `.cogs/sheet.tsv` and all headers are added to `.cogs/field.tsv`, if they do not already exist with the default datatype of `cogs:text` (text string).
+Running `add` will begin tracking a local TSV or CSV table. The table details (path, name/title, and description) get added to `.cogs/sheet.tsv`.
 
 ```
 cogs add [path] -d "[description]"
@@ -332,7 +332,7 @@ Running `fetch` will sync the local `.cogs/` directory with all remote spreadshe
 cogs fetch
 ```
 
-This will download all sheets in the spreadsheet to that directory as `{sheet-title}.tsv` - this will overwrite the existing sheets in `.cogs/tracked/`, but will not overwrite the local versions specified by their path. As the sheets are downloaded, the fields are checked against existing fields in `.cogs/field.tsv` and any new fields are added with the default datatype of `cogs:text` (text string). Any sheets that have been added with `add` and then pushed to the remote sheet with `push` will be given their IDs in `.cogs/sheet.tsv`.
+This will download all sheets in the spreadsheet to that directory as `{sheet-title}.tsv` - this will overwrite the existing sheets in `.cogs/tracked/`, but will not overwrite the local versions specified by their path. Any sheets that have been added with `add` and then pushed to the remote sheet with `push` will be given their IDs in `.cogs/sheet.tsv`.
 
 `.cogs/format.tsv` and `.cogs/note.tsv` are also updated for any cell formatting or notes on cells, respectively. Each unique format is given a numerical ID and is stored as [CellFormat JSON](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/cells#cellformat).
 
@@ -363,12 +363,12 @@ Options:
 - `-r`/`--role`: role of the user specified by `--user`: `writer` or `reader`
 - `-U`/`--users`: path to TSV containing emails and roles for multiple users (header optional)
 
-Three files are created in the `.cogs/` directory when running `init`:
+The following files are created in the `.cogs/` directory when running `init`:
 - `config.tsv`: COGS configuration, including the spreadsheet details 
-- `field.tsv`: Field names used in sheets (contains default COGS fields)
 - `format.tsv`: Sheet ID, cell location or range, and format IDs (the format for each format ID is stored as a JSON dictionary in `.cogs/formats.json`)
 - `note.tsv`: Sheet ID, cell location, and note for all notes
 - `sheet.tsv`: Sheet names in spreadsheet and details (empty) - the sheets correspond to local tables
+- `validation.tsv`: Data validation conditions
 
 All other tasks will fail if a COGS project has not been initialized in the working directory.
 
@@ -422,7 +422,7 @@ We recommend running `cogs push` after `cogs mv` to keep the remote spreadsheet 
 
 ### `rm`
 
-Running `rm` will stop tracking one or more local sheets. They are removed from `.cogs/sheet.tsv`, and the `.cogs/field.tsv` is updated to remove the fields that were unique to those sheets. Additionally, this does not delete any local copies of sheets specified by their paths.
+Running `rm` will stop tracking one or more local sheets. This does not delete any local copies of sheets specified by their paths.
 ```
 cogs rm [paths]
 ```

--- a/cogs/fetch.py
+++ b/cogs/fetch.py
@@ -18,7 +18,6 @@ from cogs.helpers import (
     set_logging,
     validate_cogs_project,
     get_client_from_config,
-    maybe_update_fields,
     update_data_validation,
     update_format,
     update_note,
@@ -250,9 +249,6 @@ def fetch(verbose=False):
     gc = get_client_from_config(config)
     spreadsheet = gc.open_by_key(config["Spreadsheet ID"])
 
-    # Get existing fields (headers) to see if we need to add/remove fields
-    headers = []
-
     # Get the remote sheets from spreadsheet
     sheets = spreadsheet.worksheets()
     remote_sheets = get_remote_sheets(sheets)
@@ -278,7 +274,7 @@ def fetch(verbose=False):
         format_to_id = {}
         next_fmt_id = 1
 
-    # Export the sheets as TSV to .cogs/ (while checking the fieldnames)
+    # Export the sheets as TSV to .cogs/
     # We also collect the formatting and note data for each sheet during this step
     sheet_formats = {}
     sheet_notes = {}
@@ -421,11 +417,6 @@ def fetch(verbose=False):
             lines = sheet.get_all_values()
             writer = csv.writer(f, delimiter="\t", lineterminator="\n")
             writer.writerows(lines)
-            if lines:
-                headers.extend(lines[0])
-
-    # Maybe update fields if they have changed
-    maybe_update_fields(cogs_dir, headers)
 
     # Write or rewrite formats JSON with new dict
     with open(f"{cogs_dir}/formats.json", "w") as f:

--- a/cogs/init.py
+++ b/cogs/init.py
@@ -128,7 +128,8 @@ def get_users(user=None, users_file=None, role="writer"):
 
 
 def write_data(sheet, title, credentials=None):
-    """Create COGS data files: config.tsv, sheet.tsv, and field.tsv."""
+    """Create COGS data files in COGS directory: config.tsv, sheet.tsv, format.tsv, formats.json,
+    note.tsv, and validation.tsv."""
     # Create the "tracked" directory
     os.mkdir(".cogs/tracked")
 
@@ -152,17 +153,6 @@ def write_data(sheet, title, credentials=None):
             fieldnames=["ID", "Title", "Path", "Description", "Frozen Rows", "Frozen Columns",],
         )
         writer.writeheader()
-
-    # field.tsv contains the field headers used in the sheets
-    with open(".cogs/field.tsv", "w") as f:
-        writer = csv.DictWriter(
-            f,
-            delimiter="\t",
-            lineterminator="\n",
-            fieldnames=["Field", "Label", "Datatype", "Description"],
-        )
-        writer.writeheader()
-        writer.writerows(default_fields)
 
     # format.tsv contains all cells with formats -> format IDs
     with open(".cogs/format.tsv", "w") as f:

--- a/cogs/rm.py
+++ b/cogs/rm.py
@@ -14,7 +14,7 @@ from cogs.helpers import (
 
 def rm(paths, verbose=False):
     """Remove a table (TSV or CSV) from the COGS project. 
-    This updates sheet.tsv and field.tsv and delete the according cached file."""
+    This updates sheet.tsv and deletes the corresponding cached file."""
     set_logging(verbose)
     cogs_dir = validate_cogs_project()
 

--- a/cogs/rm.py
+++ b/cogs/rm.py
@@ -1,9 +1,7 @@
 import csv
-import os
 
 from cogs.exceptions import RmError
 from cogs.helpers import (
-    get_fields,
     get_tracked_sheets,
     set_logging,
     validate_cogs_project,
@@ -57,47 +55,6 @@ def rm(paths, verbose=False):
             if title not in sheets_to_remove.keys():
                 sheet["Title"] = title
                 writer.writerow(sheet)
-
-    # Get the headers from all files and remove only the ones that are unique to the tracked file(s)
-    fields_all = set()
-    fields_candidates_for_removal = set()
-
-    for title, sheet in sheets.items():
-        if (
-            not os.path.exists(f"{cogs_dir}/tracked/{title}.tsv")
-            or os.stat(f"{cogs_dir}/tracked/{title}.tsv").st_size == 0
-        ):
-            continue
-        path = f"{cogs_dir}/tracked/{title}.tsv"
-        with open(path, "r") as sheet_file:
-            try:
-                reader = csv.DictReader(sheet_file, delimiter="\t")
-            except csv.Error as e:
-                raise RmError(f"unable to read {path} as a TSV\nCAUSE:{str(e)}")
-
-            if title in sheets_to_remove.keys():
-                fields_candidates_for_removal = fields_candidates_for_removal | set(
-                    reader.fieldnames
-                )
-            else:
-                fields_all = fields_all | set(reader.fieldnames)
-
-    fields_to_remove = fields_candidates_for_removal - fields_all
-
-    original_fields = get_fields(cogs_dir)
-
-    with open(f"{cogs_dir}/field.tsv", "w") as f:
-        writer = csv.DictWriter(
-            f,
-            delimiter="\t",
-            lineterminator="\n",
-            fieldnames=["Field", "Label", "Datatype", "Description"],
-        )
-        writer.writeheader()
-        for field, items in original_fields.items():
-            if items["Label"] not in fields_to_remove:
-                items["Field"] = field
-                writer.writerow(items)
 
     # Update formats and notes
     sheet_formats = get_sheet_formats(cogs_dir)


### PR DESCRIPTION
As discussed in #99, we do not actually need the `field.tsv` configuration table.