### PR TITLE
Clean up some rough edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ cogs add [path] -t "[title]"
 
 This does not immediately change the Google Sheet -- use `cogs push` to push all tracked local tables to the project spreadsheet.
 
+If an added path does not exist, COGS will create an empty file at that location.
+
 #### Adding an Ignored Sheet
 
 By default, COGS ignores any untracked remote sheets. If you wish to start tracking a new remote sheet, you can do this by passing the sheet title to `add`:
@@ -129,13 +131,21 @@ By default, COGS ignores any untracked remote sheets. If you wish to start track
 cogs add [title]
 ```
 
-The default path for pulling changes from this newly-added sheet will be the current working directory (the same directory as `.cogs/` is in) and will be a lowercase, space-replaced version of the title (e.g. `My Sheet` becomes `my_sheet.tsv`). If you already have a tracked sheet at this location, the date & time will be appended to the path (e.g., `my_sheet_20200922_103045.tsv` for a sheet fetched at 10:30:45 on 2020/09/22). This path can be updated with [`cogs mv`](#mv).
+The default path for pulling changes from this newly-added sheet will be the current working directory (the same directory as `.cogs/` is in) and will be a lowercase, space-replaced version of the title (e.g. `My Sheet` becomes `my_sheet.tsv`). If you already have a tracked sheet at this location, the date & time will be appended to the path (e.g., `my_sheet_20200922_103045.tsv` for a sheet fetched at 10:30:45 on 2020/09/22). This path can be updated with [`cogs mv`](#mv). Alternatively, if you want to specify a path immediately, you can:
+
+```
+cogs add [path] -t [title]
+```
+
+... where the "title" is the sheet title of the existing ignored sheet.
 
 You can also add *all* ignored sheets using the `-a`/`--all` flag:
 
 ```
 cogs add --all
 ```
+
+We recommend running `cogs fetch` or `cogs pull` immediately after adding ignored sheets to sync your `.cogs` directory.
 
 ### `apply`
 
@@ -291,6 +301,8 @@ To transfer ownership, click "Share" again and click the drop-down next to the s
 
 Please be aware that if you do not transfer ownership to the service account, `cogs delete` will not work. All other commands will work with just "Editor" access. If you do transfer ownership, you can always transfer ownership back to yourself using the [`share`](#share) command.
 
+`connect` will automatically fetch the existing sheets from the remote Google Spreadsheet. To get the local copies, just run `cogs merge`.
+
 ### `delete`
 
 Running `delete` reads the configuration data in `.cogs/config.tsv` to retrieve the spreadsheet ID. This spreadsheet is deleted in Google Sheets and the `.cogs` directory containing all project data is also removed. Any local TSV/CSV tables specified as sheets in the spreadsheet are left untouched.
@@ -442,15 +454,19 @@ Running `mv` will update the path of a local sheet.
 cogs mv [old_path] [new_path]
 ```
 
-The old path must exist as a local file. It will be renamed to the new path during this process. If the basename of the new path (e.g., `tables/foo.tsv` -> `foo`) is already a tracked sheet, this command will fail as you cannot have two sheets with the same name.
+This will only change the local path, not the sheet title. If you also wish to rename the sheet, you can do this with the `-t`/`--title` option:
+
+```
+cogs mv [old_path] [new_path] -t [new_title]
+```
 
 We recommend running `cogs push` after `cogs mv` to keep the remote spreadsheet in sync.
 
 ### `rm`
 
-Running `rm` will stop tracking one or more local sheets. This does not delete any local copies of sheets specified by their paths.
+Running `rm` will stop tracking one or more local sheets. This will delete all local copies of the included paths, unless you include the optional `-k`/`--keep` flag.
 ```
-cogs rm [paths]
+cogs rm path [path...] [-k]
 ```
 
 This does not delete the sheet(s) from the spreadsheet - use `cogs push` to push all local changes to the remote spreadsheet and remove cached data about the sheet.

--- a/cogs/add.py
+++ b/cogs/add.py
@@ -13,11 +13,21 @@ def add(path, title=None, description=None, freeze_row=0, freeze_column=0, verbo
     """Add a table (TSV or CSV) to the COGS project. This updates sheet.tsv."""
     set_logging(verbose)
     cogs_dir = validate_cogs_project()
+    sheets = get_tracked_sheets(cogs_dir)
+
+    if path in sheets and sheets[path]["Ignore"]:
+        # The provided path is just the title of an ignored sheet
+        add_ignored(cogs_dir, sheets, path, None, description=description)
+        return
+    if title in sheets and sheets[title]["Ignore"]:
+        # A path to write the ignored sheet was provided
+        add_ignored(cogs_dir, sheets, title, path, description=description)
+        return
 
     if not os.path.exists(path):
-        # Not a path, assume this is a title of an ignored sheet
-        add_ignored(cogs_dir, path, description=description)
-        return
+        # Create an empty file if the file doesn't exist
+        f = open(path, "w")
+        f.close()
 
     if not title:
         # Create the sheet title from file basename
@@ -38,7 +48,7 @@ def add(path, title=None, description=None, freeze_row=0, freeze_column=0, verbo
     if not description:
         description = ""
 
-    # Finally, add this TSV to sheet.tsv
+    # Finally, add this TSV to sheet.tsv & to tracked folder
     with open(f"{cogs_dir}/sheet.tsv", "a") as f:
         writer = csv.DictWriter(
             f,
@@ -95,23 +105,19 @@ def add_all(verbose=False):
     update_sheet(cogs_dir, sheet_lines, [])
 
 
-def add_ignored(cogs_dir, title, description=None):
+def add_ignored(cogs_dir, sheets, title, path, description=None):
     """Add a table currently tracked in sheet.tsv where Ignore=True."""
-    sheets = get_tracked_sheets(cogs_dir)
-    if title not in sheets:
-        raise AddError(f"'{title}' is neither an existing path nor an ignored sheet")
-
     details = sheets[title]
-    if not details.get("Ignore"):
-        raise AddError(f"'{title}' is already a tracked sheet title")
 
     del details["Ignore"]
     if description:
         details["Description"] = description
-    path = re.sub(r"[^A-Za-z0-9]+", "_", title.lower()) + ".tsv"
-    if os.path.exists(path):
-        now = datetime.now().strftime("%Y%m%d_%H%M%S")
-        path = re.sub(r"[^A-Za-z0-9]+", "_", title.lower()) + f"_{now}.tsv"
+    if not path:
+        # No path provided, create a new one
+        path = re.sub(r"[^A-Za-z0-9]+", "_", title.lower()) + ".tsv"
+        if os.path.exists(path):
+            now = datetime.now().strftime("%Y%m%d_%H%M%S")
+            path = re.sub(r"[^A-Za-z0-9]+", "_", title.lower()) + f"_{now}.tsv"
     details["Path"] = path
 
     sheets[title] = details

--- a/cogs/add.py
+++ b/cogs/add.py
@@ -48,7 +48,7 @@ def add(path, title=None, description=None, freeze_row=0, freeze_column=0, verbo
     if not description:
         description = ""
 
-    # Finally, add this TSV to sheet.tsv & to tracked folder
+    # Finally, add this TSV to sheet.tsv
     with open(f"{cogs_dir}/sheet.tsv", "a") as f:
         writer = csv.DictWriter(
             f,

--- a/cogs/cli.py
+++ b/cogs/cli.py
@@ -188,6 +188,9 @@ def main():
     sp.add_argument("path", help="Path of local sheet to move")
     sp.add_argument("new_path", help="New path for local sheet")
     sp.add_argument(
+        "-t", "--title", help="New title (if not specified, sheet title will remain the same)"
+    )
+    sp.add_argument(
         "-f",
         "--force",
         help="Overwrite existing files at the new-path location without confirming",
@@ -218,6 +221,9 @@ def main():
         "rm", parents=[global_parser], description=rm_msg, usage="cogs rm PATH [PATH ...]",
     )
     sp.add_argument("paths", help="Path(s) to TSV or CSV to remove from COGS project", nargs="+")
+    sp.add_argument(
+        "-k", "--keep", help="If included, keep local copies of sheets", action="store_true"
+    )
     sp.set_defaults(func=run_rm)
 
     # ------------------------------- share -------------------------------
@@ -295,6 +301,8 @@ def run_connect(args):
         if not success:
             # Exit with error status without deleting COGS directory
             sys.exit(1)
+        # Always fetch after connecting
+        fetch(verbose=args.verbose)
     except CogsError as e:
         # Exit with error status AND delete directory
         logging.critical(str(e))
@@ -387,7 +395,7 @@ def run_merge(args):
 def run_mv(args):
     """Wrapper for mv function."""
     try:
-        mv(args.path, args.new_path, force=args.force, verbose=args.verbose)
+        mv(args.path, args.new_path, new_title=args.title, force=args.force, verbose=args.verbose)
     except CogsError as e:
         logging.critical(str(e))
         sys.exit(1)
@@ -424,7 +432,7 @@ def run_push(args):
 def run_rm(args):
     """Wrapper for rm function."""
     try:
-        rm(args.paths, verbose=args.verbose)
+        rm(args.paths, keep=args.keep, verbose=args.verbose)
     except CogsError as e:
         logging.critical(str(e))
         sys.exit(1)

--- a/cogs/rm.py
+++ b/cogs/rm.py
@@ -14,7 +14,7 @@ from cogs.helpers import (
 )
 
 
-def rm(paths, verbose=False):
+def rm(paths, keep=False, verbose=False):
     """Remove a table (TSV or CSV) from the COGS project. 
     This updates sheet.tsv and deletes the corresponding cached file."""
     set_logging(verbose)
@@ -49,6 +49,12 @@ def rm(paths, verbose=False):
             f"unable to remove {len(sheets_to_remove)} tracked sheet(s) - "
             "the spreadsheet must have at least one sheet."
         )
+
+    # Maybe remove local copies
+    if not keep:
+        for p in paths:
+            if os.path.exists(p):
+                os.remove(p)
 
     # Remove the cached copies
     for sheet_title in sheets_to_remove.keys():


### PR DESCRIPTION
Resolves #120 

Changes:
* COGS will create an empty file at a location if a path specified by `add` does not exist
* You can now specify a path for an ignored sheet
* `connect` fetches all data after initializing the COGS directory
* You can mv into a directory just by passing the directory name (e.g., `cogs mv foo.tsv bar/`)
* `mv` does not rename the sheet title, unless specified by `--title`
* `rm` deletes local copies, unless the `--keep` flag is included