### PR TITLE
Fix behavior on renamed sheets

### DIFF
--- a/cogs/clear.py
+++ b/cogs/clear.py
@@ -48,7 +48,10 @@ def clear_formats(cogs_dir, sheet_title):
             fmt_rows.append({"Sheet Title": sheet_title, "Cell": cell, "Format ID": fmt})
     with open(f"{cogs_dir}/format.tsv", "w") as f:
         writer = csv.DictWriter(
-            f, delimiter="\t", lineterminator="\n", fieldnames=["Sheet Title", "Cell", "Format ID"],
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["Sheet Title", "Cell", "Format ID"],
         )
         writer.writeheader()
         writer.writerows(fmt_rows)
@@ -67,7 +70,10 @@ def clear_notes(cogs_dir, sheet_title):
             note_rows.append({"Sheet Title": sheet_title, "Cell": cell, "Note": note})
     with open(f"{cogs_dir}/note.tsv", "w") as f:
         writer = csv.DictWriter(
-            f, delimiter="\t", lineterminator="\n", fieldnames=["Sheet Title", "Cell", "Note"],
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["Sheet Title", "Cell", "Note"],
         )
         writer.writeheader()
         writer.writerows(note_rows)

--- a/cogs/cli.py
+++ b/cogs/cli.py
@@ -100,10 +100,16 @@ def main():
 
     # ------------------------------- apply -------------------------------
     sp = subparsers.add_parser(
-        "apply", parents=[global_parser], description=apply_msg, usage="cogs apply [PATH ...]",
+        "apply",
+        parents=[global_parser],
+        description=apply_msg,
+        usage="cogs apply [PATH ...]",
     )
     sp.add_argument(
-        "paths", nargs="*", default=None, help="Path(s) to table(s) to apply",
+        "paths",
+        nargs="*",
+        default=None,
+        help="Path(s) to table(s) to apply",
     )
     sp.set_defaults(func=run_apply)
 
@@ -137,14 +143,20 @@ def main():
 
     # ------------------------------- delete -------------------------------
     sp = subparsers.add_parser(
-        "delete", parents=[global_parser], description=delete_msg, usage="cogs delete [-f]",
+        "delete",
+        parents=[global_parser],
+        description=delete_msg,
+        usage="cogs delete [-f]",
     )
     sp.set_defaults(func=run_delete)
     sp.add_argument("-f", "--force", action="store_true", help="Delete without confirming")
 
     # ------------------------------- diff -------------------------------
     sp = subparsers.add_parser(
-        "diff", parents=[global_parser], description=diff_msg, usage="cogs diff [PATH ...]",
+        "diff",
+        parents=[global_parser],
+        description=diff_msg,
+        usage="cogs diff [PATH ...]",
     )
     sp.set_defaults(func=run_diff)
     sp.add_argument("paths", nargs="*", help="Paths to local sheets to diff")
@@ -166,7 +178,10 @@ def main():
     sp.add_argument("-t", "--title", required=True, help="Title of the project")
     sp.add_argument("-u", "--user", help="Email (user) to share spreadsheet with")
     sp.add_argument(
-        "-r", "--role", default="writer", help="Role for specified user (default: owner)",
+        "-r",
+        "--role",
+        default="writer",
+        help="Role for specified user (default: owner)",
     )
     sp.add_argument("-U", "--users", help="TSV containing user emails and their roles")
     sp.set_defaults(func=run_init)
@@ -183,7 +198,10 @@ def main():
 
     # ------------------------------- mv -------------------------------
     sp = subparsers.add_parser(
-        "mv", parents=[global_parser], description=mv_msg, usage="cogs mv PATH NEW_PATH",
+        "mv",
+        parents=[global_parser],
+        description=mv_msg,
+        usage="cogs mv PATH NEW_PATH",
     )
     sp.add_argument("path", help="Path of local sheet to move")
     sp.add_argument("new_path", help="New path for local sheet")
@@ -200,7 +218,10 @@ def main():
 
     # ------------------------------- open -------------------------------
     sp = subparsers.add_parser(
-        "open", parents=[global_parser], description=open_msg, usage="cogs open",
+        "open",
+        parents=[global_parser],
+        description=open_msg,
+        usage="cogs open",
     )
     sp.set_defaults(func=run_open)
 
@@ -218,7 +239,10 @@ def main():
 
     # -------------------------------- rm --------------------------------
     sp = subparsers.add_parser(
-        "rm", parents=[global_parser], description=rm_msg, usage="cogs rm PATH [PATH ...]",
+        "rm",
+        parents=[global_parser],
+        description=rm_msg,
+        usage="cogs rm PATH [PATH ...]",
     )
     sp.add_argument("paths", help="Path(s) to TSV or CSV to remove from COGS project", nargs="+")
     sp.add_argument(
@@ -243,7 +267,10 @@ def main():
 
     # -------------------------------- status --------------------------------
     sp = subparsers.add_parser(
-        "status", parents=[global_parser], description=status_msg, usage="cogs status",
+        "status",
+        parents=[global_parser],
+        description=status_msg,
+        usage="cogs status",
     )
     sp.set_defaults(func=run_status)
 

--- a/cogs/fetch.py
+++ b/cogs/fetch.py
@@ -108,7 +108,9 @@ def get_cell_data(cogs_dir, sheet):
     # Build service to send request & execute
     service = discovery.build("sheets", "v4", credentials=credentials, cache=MemoryCache())
     request = service.spreadsheets().get(
-        spreadsheetId=spreadsheet_id, ranges=sheet_name, fields="sheets(data(rowData(values(*))))",
+        spreadsheetId=spreadsheet_id,
+        ranges=f"'{sheet_name}'",
+        fields="sheets(data(rowData(values(*))))",
     )
     resp = request.execute()
 
@@ -188,9 +190,7 @@ def remove_sheets(cogs_dir, sheets, tracked_sheets, renamed_local, renamed_remot
     }
 
     # The key of renamed_remote is what remains in cache & needs to be updated
-    old_remote_titles = {
-        re.sub(r"[^A-Za-z0-9]+", "_", x["new"].lower()): x["new"] for x in renamed_remote.keys()
-    }
+    old_remote_titles = {re.sub(r"[^A-Za-z0-9]+", "_", x.lower()): x for x in renamed_remote.keys()}
 
     # All current remote titles
     remote_titles = {re.sub(r"[^A-Za-z0-9]+", "_", x.title.lower()): x.title for x in sheets}
@@ -200,10 +200,7 @@ def remove_sheets(cogs_dir, sheets, tracked_sheets, renamed_local, renamed_remot
     remove_from_sheet = []
     for sheet_path in cached_sheet_titles:
         if sheet_path in old_remote_titles:
-            if os.path.exists(f"{cogs_dir}/tracked/{sheet_path}.tsv"):
-                os.remove(f"{cogs_dir}/tracked/{sheet_path}.tsv")
-            old_title = old_remote_titles[sheet_path]
-            remove_from_sheet.append(old_title)
+            continue
         elif sheet_path not in remote_titles and sheet_path not in new_local_titles:
             # This sheet has a cached copy but does not exist in the remote version
             # It has either been removed from remote or was newly added to cache
@@ -220,7 +217,7 @@ def remove_sheets(cogs_dir, sheets, tracked_sheets, renamed_local, renamed_remot
     # Find tracked sheets that have been removed remotely (check by ID)
     remote_ids = [x.id for x in sheets]
     for sheet_title, details in tracked_sheets.items():
-        if details["ID"] not in remote_ids:
+        if details["ID"] not in remote_ids and sheet_title not in renamed_remote.keys():
             logging.info(f"Removing tracked sheet '{sheet_title}' (deleted remotely)")
             remove_from_sheet.append(sheet_title)
 

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -341,10 +341,12 @@ def set_logging(verbose):
         logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 
 
-def update_format(cogs_dir, sheet_formats, removed_titles):
+def update_format(cogs_dir, sheet_formats, removed_titles, overwrite=False):
     """Update format.tsv with current remote formatting.
     Remove any lines with a Sheet ID in removed_ids."""
-    current_sheet_formats = get_sheet_formats(cogs_dir)
+    current_sheet_formats = {}
+    if not overwrite:
+        current_sheet_formats = get_sheet_formats(cogs_dir)
     fmt_rows = []
     for sheet_title, formats in sheet_formats.items():
         current_sheet_formats[sheet_title] = formats
@@ -355,16 +357,21 @@ def update_format(cogs_dir, sheet_formats, removed_titles):
             fmt_rows.append({"Sheet Title": sheet_title, "Cell": cell, "Format ID": fmt})
     with open(f"{cogs_dir}/format.tsv", "w") as f:
         writer = csv.DictWriter(
-            f, delimiter="\t", lineterminator="\n", fieldnames=["Sheet Title", "Cell", "Format ID"],
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["Sheet Title", "Cell", "Format ID"],
         )
         writer.writeheader()
         writer.writerows(fmt_rows)
 
 
-def update_note(cogs_dir, sheet_notes, removed_titles):
+def update_note(cogs_dir, sheet_notes, removed_titles, overwrite=False):
     """Update note.tsv with current remote notes.
     Remove any lines with a Sheet ID in removed_ids."""
-    current_sheet_notes = get_sheet_notes(cogs_dir)
+    current_sheet_notes = {}
+    if not overwrite:
+        current_sheet_notes = get_sheet_notes(cogs_dir)
     note_rows = []
     for sheet_title, notes in sheet_notes.items():
         current_sheet_notes[sheet_title] = notes
@@ -375,16 +382,21 @@ def update_note(cogs_dir, sheet_notes, removed_titles):
             note_rows.append({"Sheet Title": sheet_title, "Cell": cell, "Note": note})
     with open(f"{cogs_dir}/note.tsv", "w") as f:
         writer = csv.DictWriter(
-            f, delimiter="\t", lineterminator="\n", fieldnames=["Sheet Title", "Cell", "Note"],
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["Sheet Title", "Cell", "Note"],
         )
         writer.writeheader()
         writer.writerows(note_rows)
 
 
-def update_data_validation(cogs_dir, sheet_dv_rules, removed_titles):
-    """"""
+def update_data_validation(cogs_dir, sheet_dv_rules, removed_titles, overwrite=False):
+    """ """
     # TODO - can we be smarter and error on overlap?
-    current_sheet_dv_rules = get_data_validation(cogs_dir)
+    current_sheet_dv_rules = {}
+    if not overwrite:
+        current_sheet_dv_rules = get_data_validation(cogs_dir)
     dv_rows = []
     for sheet_title, dv_rules in sheet_dv_rules.items():
         if sheet_title in current_sheet_dv_rules:
@@ -411,7 +423,7 @@ def update_data_validation(cogs_dir, sheet_dv_rules, removed_titles):
 
 
 def update_sheet(cogs_dir, sheet_details, removed_titles):
-    """"""
+    """ """
     rows = [details for details in sheet_details if details["Title"] not in removed_titles]
     with open(f"{cogs_dir}/sheet.tsv", "w") as f:
         writer = csv.DictWriter(

--- a/cogs/init.py
+++ b/cogs/init.py
@@ -49,30 +49,90 @@ default_formats = {
         "backgroundColor": {"blue": 0.7019608, "green": 0.7019608, "red": 1},
         "backgroundColorStyle": {"rgbColor": {"blue": 0.7019608, "green": 0.7019608, "red": 1}},
         "borders": {
-            "bottom": {"color": {}, "colorStyle": {"rgbColor": {}}, "style": "SOLID", "width": 1,},
-            "left": {"color": {}, "colorStyle": {"rgbColor": {}}, "style": "SOLID", "width": 1,},
-            "right": {"color": {}, "colorStyle": {"rgbColor": {}}, "style": "SOLID", "width": 1,},
-            "top": {"color": {}, "colorStyle": {"rgbColor": {}}, "style": "SOLID", "width": 1,},
+            "bottom": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "left": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "right": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "top": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
         },
     },
     "1": {
         "backgroundColor": {"blue": 0.5921569, "green": 1, "red": 1},
         "backgroundColorStyle": {"rgbColor": {"blue": 0.5921569, "green": 1, "red": 1}},
         "borders": {
-            "bottom": {"color": {}, "colorStyle": {"rgbColor": {}}, "style": "SOLID", "width": 1,},
-            "left": {"color": {}, "colorStyle": {"rgbColor": {}}, "style": "SOLID", "width": 1,},
-            "right": {"color": {}, "colorStyle": {"rgbColor": {}}, "style": "SOLID", "width": 1,},
-            "top": {"color": {}, "colorStyle": {"rgbColor": {}}, "style": "SOLID", "width": 1,},
+            "bottom": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "left": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "right": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "top": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
         },
     },
     "2": {
         "backgroundColor": {"blue": 1, "green": 0.87058824, "red": 0.7254902},
         "backgroundColorStyle": {"rgbColor": {"blue": 1, "green": 0.87058824, "red": 0.7254902}},
         "borders": {
-            "bottom": {"color": {}, "colorStyle": {"rgbColor": {}}, "style": "SOLID", "width": 1,},
-            "left": {"color": {}, "colorStyle": {"rgbColor": {}}, "style": "SOLID", "width": 1,},
-            "right": {"color": {}, "colorStyle": {"rgbColor": {}}, "style": "SOLID", "width": 1,},
-            "top": {"color": {}, "colorStyle": {"rgbColor": {}}, "style": "SOLID", "width": 1,},
+            "bottom": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "left": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "right": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
+            "top": {
+                "color": {},
+                "colorStyle": {"rgbColor": {}},
+                "style": "SOLID",
+                "width": 1,
+            },
         },
     },
 }
@@ -165,7 +225,10 @@ def write_data(sheet, title, credentials=None):
     # format.tsv contains all cells with formats -> format IDs
     with open(".cogs/format.tsv", "w") as f:
         writer = csv.DictWriter(
-            f, delimiter="\t", lineterminator="\n", fieldnames=["Sheet Title", "Cell", "Format ID"],
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["Sheet Title", "Cell", "Format ID"],
         )
         writer.writeheader()
 
@@ -175,7 +238,10 @@ def write_data(sheet, title, credentials=None):
     # note.tsv contains all cells with notes -> note
     with open(".cogs/note.tsv", "w") as f:
         writer = csv.DictWriter(
-            f, delimiter="\t", lineterminator="\n", fieldnames=["Sheet Title", "Cell", "Note"],
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=["Sheet Title", "Cell", "Note"],
         )
         writer.writeheader()
 

--- a/cogs/merge.py
+++ b/cogs/merge.py
@@ -10,6 +10,7 @@ from cogs.helpers import (
     get_renamed_sheets,
     get_tracked_sheets,
     set_logging,
+    update_sheet,
     validate_cogs_project,
 )
 
@@ -30,13 +31,25 @@ def merge(verbose=False):
     cached_sheets = get_cached_sheets(cogs_dir)
     tracked_sheets = get_tracked_sheets(cogs_dir)
     tracked_cached = [re.sub(r"[^A-Za-z0-9]+", "_", x.lower()) for x in tracked_sheets.keys()]
-    remove_sheets = [s for s in cached_sheets if s not in tracked_cached]
 
     # Get the list of ignored sheet titles
     ignore = [x for x, y in tracked_sheets.items() if y.get("Ignore") == "True"]
 
+    renamed_sheets = get_renamed_sheets(cogs_dir)
+    renamed_local = {
+        old: details for old, details in renamed_sheets.items() if details["where"] == "local"
+    }
+    renamed_remote = {
+        old: details for old, details in renamed_sheets.items() if old not in renamed_local
+    }
+    # Add new remotes to tracked cached
+    for details in renamed_remote.values():
+        tracked_cached.append(re.sub(r"[^A-Za-z0-9]+", "_", details["new"].lower()))
+
+    remove_sheets = [s for s in cached_sheets if s not in tracked_cached]
+
     for sheet_title, details in tracked_sheets.items():
-        if sheet_title in ignore:
+        if sheet_title in ignore or sheet_title in renamed_remote:
             continue
         cached_path = get_cached_path(cogs_dir, sheet_title)
         local_sheet = details["Path"]
@@ -46,16 +59,45 @@ def merge(verbose=False):
                 copy_to_csv(cached_path, local_sheet)
             else:
                 shutil.copyfile(cached_path, local_sheet)
+
+    # Handle renamed remote files by replacing their cached copies and adding to sheet.tsv
+    for old_title, details in renamed_remote.items():
+        new_title = details["new"]
+        cached_path = get_cached_path(cogs_dir, old_title)
+        logging.info(f"Removing '{old_title}' from cached sheets and replacing with '{new_title}'")
+        if os.path.exists(cached_path):
+            os.remove(cached_path)
+
+        # Write new copy
+        local_sheet = details["path"]
+        cached_path = get_cached_path(cogs_dir, new_title)
+        if os.path.exists(cached_path):
+            logging.info(f"Writing '{new_title}' to {local_sheet}")
+            if local_sheet.endswith(".csv"):
+                copy_to_csv(cached_path, local_sheet)
+            else:
+                shutil.copyfile(cached_path, local_sheet)
+
+        # Update sheet.tsv
+        sheet_details = tracked_sheets[old_title]
+        del tracked_sheets[old_title]
+        sheet_details["Path"] = local_sheet
+        tracked_sheets[new_title] = sheet_details
+
     for sheet_title in remove_sheets:
         logging.info(f"Removing '{sheet_title}' from cached sheets")
         os.remove(f"{cogs_dir}/tracked/{sheet_title}.tsv")
 
-    renamed_sheets = get_renamed_sheets(cogs_dir)
-    renamed_local = {
-        old: details for old, details in renamed_sheets.items() if details["where"] == "local"
-    }
     with open(f"{cogs_dir}/renamed.tsv", "w") as f:
         for old_title, details in renamed_local.items():
             new_title = details["new"]
             path = details["path"]
             f.write(f"{old_title}\t{new_title}\t{path}\tlocal\n")
+
+    if renamed_remote:
+        # We need to update sheet.tsv if anything was renamed remotely
+        sheet_details = []
+        for title, details in tracked_sheets.items():
+            details["Title"] = title
+            sheet_details.append(details)
+        update_sheet(cogs_dir, sheet_details, [])

--- a/cogs/mv.py
+++ b/cogs/mv.py
@@ -65,11 +65,37 @@ def mv(path, new_path, new_title=None, force=False, verbose=False):
         logging.info(f"Renaming '{selected_sheet}' to '{new_title}'")
 
         # Check if cached path exists - may not if it has not been pushed or pulled yet
-        old_cached_path = get_cached_path(cogs_dir, new_title)
+        old_cached_path = get_cached_path(cogs_dir, selected_sheet)
         if os.path.exists(old_cached_path):
             shutil.copyfile(old_cached_path, new_cached_path)
-            with open(f"{cogs_dir}/renamed.tsv", "a") as f:
-                f.write(f"{selected_sheet}\t{new_title}\t{new_path}\tlocal\n")
+
+        # Add to renamed.tsv
+        with open(f"{cogs_dir}/renamed.tsv", "a") as f:
+            f.write(f"{selected_sheet}\t{new_title}\t{new_path}\tlocal\n")
+
+        # Maybe update format.tsv
+        sheet_formats = get_sheet_formats(cogs_dir)
+        this_formats = sheet_formats.get(selected_sheet)
+        if this_formats:
+            del sheet_formats[selected_sheet]
+            sheet_formats[new_title] = this_formats
+            update_format(cogs_dir, sheet_formats, [], overwrite=True)
+
+        # Maybe update notes.tsv
+        sheet_notes = get_sheet_notes(cogs_dir)
+        this_notes = sheet_notes.get(selected_sheet)
+        if this_notes:
+            del sheet_notes[selected_sheet]
+            sheet_notes[new_title] = this_notes
+            update_note(cogs_dir, sheet_notes, [])
+
+        # Maybe update validation.tsv
+        data_validation = get_data_validation(cogs_dir)
+        this_dv = data_validation.get(selected_sheet)
+        if this_dv:
+            del data_validation[selected_sheet]
+            data_validation[new_title] = this_dv
+            update_data_validation(cogs_dir, data_validation, [])
 
     # Get new rows of sheet.tsv to write
     rows = []

--- a/cogs/push.py
+++ b/cogs/push.py
@@ -99,7 +99,9 @@ def push_data(cogs_dir, spreadsheet, tracked_sheets, remote_sheets):
 
         # Add new values to ws from local
         spreadsheet.values_update(
-            f"{sheet_title}!A1", params={"valueInputOption": "RAW"}, body={"values": rows},
+            f"{sheet_title}!A1",
+            params={"valueInputOption": "RAW"},
+            body={"values": rows},
         )
 
         # Add frozen rows & cols
@@ -185,7 +187,13 @@ def push_formats(spreadsheet, id_to_format, sheet_formats):
         requests = []
         for cell, fmt_id in cell_to_format.items():
             fmt = id_to_format[int(fmt_id)]
-            cell_format = gf.CellFormat.from_props(fmt)
+            try:
+                cell_format = gf.CellFormat.from_props(fmt)
+            except:
+                print(fmt)
+                import sys
+
+                sys.exit(1)
             requests.append((cell, cell_format))
         logging.info(f"adding {len(requests)} formats to sheet '{sheet_title}")
         gf.format_cell_ranges(worksheet, requests)

--- a/cogs/rm.py
+++ b/cogs/rm.py
@@ -15,7 +15,7 @@ from cogs.helpers import (
 
 
 def rm(paths, keep=False, verbose=False):
-    """Remove a table (TSV or CSV) from the COGS project. 
+    """Remove a table (TSV or CSV) from the COGS project.
     This updates sheet.tsv and deletes the corresponding cached file."""
     set_logging(verbose)
     cogs_dir = validate_cogs_project()


### PR DESCRIPTION
While making the fix in #124, I noticed some weird behavior with `status` on renaming sheets, both locally and remotely... this sent me down a bit of a rabbit hole. COGS wasn't properly displaying the rename and could cause exceptions when you tried to `pull` or `merge` (for remote renames) or `push` (for local renames).

I tested this a couple times and it seems to now behave like we expect. Running `cogs status` will show you what's renamed. If you have a remote rename and run `cogs pull` or `cogs merge`, the local sheet title will be updated. If you have a local rename (using `cogs mv`) and run `cogs push`, the remote sheet title will be updated.

I also ran `black` over the code so the following files only have formatting changes:
* `clear.py`
* `cli.py`
* `init.py`
* `rm.py`