### PR TITLE
Re-add the 'ignore' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ There are some other commands that do not correspond to any `git` actions:
 - [`cogs clear`](#clear) removes formatting, notes, and/or data validation rules from one or more sheets
 - [`cogs connect`](#connect) initiates a new COGS project by connecting an existing Google Spreadsheet
 - [`cogs delete`](#delete) destroys the spreadsheet and configuration data, but leaves local files alone
+- [`cogs ignore`](#ignore) begins ignoring a tracked sheet so that the local copy is no longer updated
 - [`cogs mv foo.tsv bar.tsv`](#mv) updates the path to the local version of a spreadsheet from `foo.tsv` to `bar.tsv`
 - [`cogs open`](#open) displays the URL of the spreadsheet
 - [`cogs share`](#share) shares the spreadsheet with specified users
@@ -369,6 +370,16 @@ If a new sheet has been added to the Google spreadsheet, this sheet will be adde
 To sync the local version of sheets with the data in `.cogs/`, run [`cogs merge`](#merge).
 
 Note that if a sheet has been _renamed_ remotely, the old sheet title will be replaced with the new sheet title. Any changes made to the local file corresponding to the old title will not be synced with the remote spreadsheet. Instead, once you run `cogs merge`, a new sheet `{new-sheet-title}.tsv` will appear in the current working directory (the same as if a new sheet were created). It is the same as if you were to delete the old sheet remotely and create a new sheet remotely with the same contents. Use `cogs merge` to write the new path - the old local file will not be deleted.
+
+### `ignore`
+
+Running `ignore` on a given sheet title will start ignoring that sheet. This means that the cached copy of the sheet in the `.cogs/` directory is deleted, and the local version will no longer be updated when running `cogs pull`.
+
+```
+cogs ignore [sheet-title]
+```
+
+You may only run `ignore` on a sheet that you are already tracking. This will *not* remove either your local copy or the remote sheet.
 
 ### `init`
 

--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -7,6 +7,7 @@ from cogs.connect import connect
 from cogs.delete import delete
 from cogs.diff import diff
 from cogs.fetch import fetch
+from cogs.ignore import ignore
 from cogs.init import init
 from cogs.ls import ls
 from cogs.mv import mv

--- a/cogs/add.py
+++ b/cogs/add.py
@@ -108,8 +108,9 @@ def add_all(verbose=False):
 def add_ignored(cogs_dir, sheets, title, path, description=None):
     """Add a table currently tracked in sheet.tsv where Ignore=True."""
     details = sheets[title]
+    path = path or details.get("Path")
 
-    del details["Ignore"]
+    details["Ignore"] = False
     if description:
         details["Description"] = description
     if not path:

--- a/cogs/cli.py
+++ b/cogs/cli.py
@@ -360,6 +360,7 @@ def run_help(args):
 
 
 def run_ignore(args):
+    """Wrapper for ignore function."""
     try:
         ignore(args.sheet_title, verbose=args.verbose)
     except CogsError as e:

--- a/cogs/cli.py
+++ b/cogs/cli.py
@@ -13,6 +13,7 @@ import cogs.delete as delete
 import cogs.diff as diff
 import cogs.fetch as fetch
 import cogs.helpers as helpers
+import cogs.ignore as ignore
 import cogs.init as init
 import cogs.ls as ls
 import cogs.mv as mv
@@ -100,16 +101,10 @@ def main():
 
     # ------------------------------- apply -------------------------------
     sp = subparsers.add_parser(
-        "apply",
-        parents=[global_parser],
-        description=apply_msg,
-        usage="cogs apply [PATH ...]",
+        "apply", parents=[global_parser], description=apply_msg, usage="cogs apply [PATH ...]",
     )
     sp.add_argument(
-        "paths",
-        nargs="*",
-        default=None,
-        help="Path(s) to table(s) to apply",
+        "paths", nargs="*", default=None, help="Path(s) to table(s) to apply",
     )
     sp.set_defaults(func=run_apply)
 
@@ -143,20 +138,14 @@ def main():
 
     # ------------------------------- delete -------------------------------
     sp = subparsers.add_parser(
-        "delete",
-        parents=[global_parser],
-        description=delete_msg,
-        usage="cogs delete [-f]",
+        "delete", parents=[global_parser], description=delete_msg, usage="cogs delete [-f]",
     )
     sp.set_defaults(func=run_delete)
     sp.add_argument("-f", "--force", action="store_true", help="Delete without confirming")
 
     # ------------------------------- diff -------------------------------
     sp = subparsers.add_parser(
-        "diff",
-        parents=[global_parser],
-        description=diff_msg,
-        usage="cogs diff [PATH ...]",
+        "diff", parents=[global_parser], description=diff_msg, usage="cogs diff [PATH ...]",
     )
     sp.set_defaults(func=run_diff)
     sp.add_argument("paths", nargs="*", help="Paths to local sheets to diff")
@@ -166,6 +155,13 @@ def main():
         "fetch", parents=[global_parser], description=fetch_msg, usage="cogs fetch"
     )
     sp.set_defaults(func=run_fetch)
+
+    # ------------------------------- ignore -------------------------------
+    sp = subparsers.add_parser(
+        "ignore", parents=[global_parser], description=ignore_msg, usage="cogs ignore [SHEET_TITLE]"
+    )
+    sp.add_argument("sheet_title", help="Title of sheet to ignore")
+    sp.set_defaults(func=run_ignore)
 
     # ------------------------------- init -------------------------------
     sp = subparsers.add_parser(
@@ -178,10 +174,7 @@ def main():
     sp.add_argument("-t", "--title", required=True, help="Title of the project")
     sp.add_argument("-u", "--user", help="Email (user) to share spreadsheet with")
     sp.add_argument(
-        "-r",
-        "--role",
-        default="writer",
-        help="Role for specified user (default: owner)",
+        "-r", "--role", default="writer", help="Role for specified user (default: owner)",
     )
     sp.add_argument("-U", "--users", help="TSV containing user emails and their roles")
     sp.set_defaults(func=run_init)
@@ -198,10 +191,7 @@ def main():
 
     # ------------------------------- mv -------------------------------
     sp = subparsers.add_parser(
-        "mv",
-        parents=[global_parser],
-        description=mv_msg,
-        usage="cogs mv PATH NEW_PATH",
+        "mv", parents=[global_parser], description=mv_msg, usage="cogs mv PATH NEW_PATH",
     )
     sp.add_argument("path", help="Path of local sheet to move")
     sp.add_argument("new_path", help="New path for local sheet")
@@ -218,10 +208,7 @@ def main():
 
     # ------------------------------- open -------------------------------
     sp = subparsers.add_parser(
-        "open",
-        parents=[global_parser],
-        description=open_msg,
-        usage="cogs open",
+        "open", parents=[global_parser], description=open_msg, usage="cogs open",
     )
     sp.set_defaults(func=run_open)
 
@@ -239,10 +226,7 @@ def main():
 
     # -------------------------------- rm --------------------------------
     sp = subparsers.add_parser(
-        "rm",
-        parents=[global_parser],
-        description=rm_msg,
-        usage="cogs rm PATH [PATH ...]",
+        "rm", parents=[global_parser], description=rm_msg, usage="cogs rm PATH [PATH ...]",
     )
     sp.add_argument("paths", help="Path(s) to TSV or CSV to remove from COGS project", nargs="+")
     sp.add_argument(
@@ -267,10 +251,7 @@ def main():
 
     # -------------------------------- status --------------------------------
     sp = subparsers.add_parser(
-        "status",
-        parents=[global_parser],
-        description=status_msg,
-        usage="cogs status",
+        "status", parents=[global_parser], description=status_msg, usage="cogs status",
     )
     sp.set_defaults(func=run_status)
 
@@ -376,6 +357,14 @@ def run_fetch(args):
 def run_help(args):
     """Wrapper for help function."""
     print(usage())
+
+
+def run_ignore(args):
+    try:
+        ignore(args.sheet_title, verbose=args.verbose)
+    except CogsError as e:
+        logging.critical(str(e))
+        sys.exit(1)
 
 
 def run_init(args):

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -310,6 +310,11 @@ def get_tracked_sheets(cogs_dir, include_no_id=True):
             if not include_no_id and sheet_id == "":
                 continue
             del row["Title"]
+            # Update ignore to a bool
+            ignore = False
+            if row.get("Ignore", "False") == "True":
+                ignore = True
+            row["Ignore"] = ignore
             sheets[title] = row
     return sheets
 

--- a/cogs/ignore.py
+++ b/cogs/ignore.py
@@ -1,0 +1,42 @@
+import logging
+import os
+
+from cogs.exceptions import IgnoreError
+from cogs.helpers import (
+    get_cached_path,
+    get_tracked_sheets,
+    set_logging,
+    update_sheet,
+    validate_cogs_project,
+)
+
+
+def ignore(sheet_title, verbose=False):
+    set_logging(verbose)
+    cogs_dir = validate_cogs_project()
+
+    sheets = get_tracked_sheets(cogs_dir)
+    sheet_details = sheets.get(sheet_title)
+    if not sheet_details:
+        raise IgnoreError(f"'{sheet_title}' is not a tracked sheet")
+    if sheet_details.get("Ignore"):
+        raise IgnoreError(f"'{sheet_title}' is already an ignored sheet")
+
+    logging.info(f"Removing '{sheet_title}' from tracking...")
+
+    # Removed cached copy
+    cached_path = get_cached_path(cogs_dir, sheet_title)
+    if os.path.exists(cached_path):
+        os.remove(cached_path)
+
+    # Update sheet.tsv
+    sheet_details["Title"] = sheet_title
+    sheet_details["Ignore"] = True
+    all_sheets = []
+    for st, details in sheets.items():
+        if st == sheet_title:
+            all_sheets.append(sheet_details)
+        else:
+            details["Title"] = st
+            all_sheets.append(details)
+    update_sheet(cogs_dir, all_sheets, [])

--- a/cogs/ignore.py
+++ b/cogs/ignore.py
@@ -12,6 +12,7 @@ from cogs.helpers import (
 
 
 def ignore(sheet_title, verbose=False):
+    """Start ignoring an existing sheet by title. This updates sheet.tsv."""
     set_logging(verbose)
     cogs_dir = validate_cogs_project()
 

--- a/tests/test_cogs.py
+++ b/tests/test_cogs.py
@@ -13,6 +13,7 @@ def test_modules():
         "exceptions",
         "fetch",
         "helpers",
+        "ignore",
         "init",
         "ls",
         "mv",


### PR DESCRIPTION
Resolves #130 - after we get this in, we should probably make a release as there are some critical bug fixes to get out (#131, #133).

### `ignore`

Running `ignore` on a given sheet title will start ignoring that sheet. This means that the cached copy of the sheet in the `.cogs/` directory is deleted, and the local version will no longer be updated when running `cogs pull`.

```
cogs ignore [sheet-title]
```

You may only run `ignore` on a sheet that you are already tracking. This will *not* remove either your local copy or the remote sheet.